### PR TITLE
fix #12, change newVersionLongText args.

### DIFF
--- a/lib/widget/update_card.dart
+++ b/lib/widget/update_card.dart
@@ -164,8 +164,8 @@ class _UpdateCardState extends State<UpdateCard> {
                           getLocalizedString(
                                 notifier?.getLocalization?.newVersionLongText,
                                 [
-                                  notifier?.appName,
-                                  notifier?.appVersion,
+                                  ((notifier?.downloadSize ?? 0) / 1024)
+                                      .toStringAsFixed(2),
                                 ],
                               ) ??
                               (getLocalizedString(

--- a/lib/widget/update_dialog.dart
+++ b/lib/widget/update_dialog.dart
@@ -197,8 +197,8 @@ class UpdateDialogWidget extends StatelessWidget {
                     )) ?? ""}, ${getLocalizedString(
                       notifier.getLocalization?.newVersionLongText,
                       [
-                        notifier.appName,
-                        notifier.appVersion,
+                        ((notifier.downloadSize ?? 0) / 1024)
+                                      .toStringAsFixed(2),
                       ],
                     ) ?? (getLocalizedString(
                       "New version is ready to download, click the button below to start downloading. This will download {} MB of data.",


### PR DESCRIPTION
When `newVersionLongText` was specified, it used `appName` and `appVersion` as arguments, while the default fallback text used download size in MB. This created confusion and potential localization issues.  
And there has no other field in `DesktopUpdateLocalization` can get download size.  
So I think this should be fixed.