### PR TITLE
Add chcp 65001 to let bat script support none ascii path on windows

### DIFF
--- a/windows/desktop_updater_plugin.cpp
+++ b/windows/desktop_updater_plugin.cpp
@@ -68,6 +68,7 @@ namespace desktop_updater
 
     const std::string batScript =
         "@echo off\n"
+        "chcp 65001 > NUL\n"
         // "echo Updating the application...\n"
         "timeout /t 2 /nobreak > NUL\n"
         // "echo Copying files...\n"


### PR DESCRIPTION
https://github.com/MarlonJD/flutter_desktop_updater/blob/0980a25e7332e1419be3f4bb5b26854313906248/windows/desktop_updater_plugin.cpp#L51-L92

We can see the path encoded as utf-8, but the code page was not explicitly set. This causes the batch script to run with the system’s default code page, which leads to errors when executing `start exePathStr` on paths containing non-ASCII characters.  
We can fix this by adding `chcp 65001` to explicitly set the code page to UTF-8.