### PR TITLE
Swapped AND condition to OR where AND makes no sense in updater_controller.dart

### DIFF
--- a/lib/updater_controller.dart
+++ b/lib/updater_controller.dart
@@ -112,7 +112,7 @@ class DesktopUpdaterController extends ChangeNotifier {
       throw Exception("Folder URL is not set");
     }
 
-    if (_changedFiles == null && _changedFiles!.isEmpty) {
+    if (_changedFiles == null || _changedFiles!.isEmpty) {
       throw Exception("Changed files are not set");
     }
 
@@ -124,17 +124,6 @@ class DesktopUpdaterController extends ChangeNotifier {
     stream.listen(
       (event) {
         _updateProgress = event;
-
-        // if (_downloadProgress >= 1.0) {
-        //   _isDownloading = false;
-        //   _downloadProgress = 1.0;
-        //   _downloadedSize = _downloadSize;
-        //   _isDownloaded = true;
-
-        //   notifyListeners();
-        //   return;
-        // }
-
         _isDownloading = true;
         _isDownloaded = false;
         _downloadProgress = event.receivedBytes / event.totalBytes;


### PR DESCRIPTION
If _changedFiles is not null condition after it is really never checked. If it is null then it crashes all the time.