### PR TITLE
timeouts have been increased

### DIFF
--- a/windows/desktop_updater_plugin.cpp
+++ b/windows/desktop_updater_plugin.cpp
@@ -70,17 +70,17 @@ namespace desktop_updater
         "@echo off\n"
         "chcp 65001 > NUL\n"
         // "echo Updating the application...\n"
-        "timeout /t 2 /nobreak > NUL\n"
+        "timeout /t 4 /nobreak > NUL\n"
         // "echo Copying files...\n"
         "xcopy /E /I /Y \"" +
         updateDirStr + "\\*\" \"" + destDirStr + "\\\"\n"
                                                  "rmdir /S /Q \"" +
         updateDirStr + "\"\n" +
         // "echo Files copied.\n"
-        "timeout /t 1 /nobreak > NUL\n"
+        "timeout /t 3 /nobreak > NUL\n"
         "start \"\" \"" +
         exePathStr + "\"\n"
-                     "timeout /t 1 /nobreak > NUL\n"
+                     "timeout /t 2 /nobreak > NUL\n"
                      // "echo Deleting temporary files...\n"
                      "del update_script.bat\n"
                      "\"\n"


### PR DESCRIPTION
An issue was observed: upon restart, the application did not have enough time to properly complete the update process, which caused the update to start again after relaunch. After increasing the timeout values, the issue was resolved.