### PR TITLE
Fix macOS relaunch after updates that replace executables

### DIFF
--- a/macos/desktop_updater/Sources/desktop_updater/DesktopUpdaterPlugin.swift
+++ b/macos/desktop_updater/Sources/desktop_updater/DesktopUpdaterPlugin.swift
@@ -140,6 +140,33 @@ public class DesktopUpdaterPlugin: NSObject, FlutterPlugin {
           rm -rf "$STAGING"
         fi
 
+        restore_execute_bits() {
+          chmod +x "$TARGET/MacOS"/* 2>/dev/null || true
+
+          if command -v file >/dev/null 2>&1; then
+            find "$TARGET/Frameworks" -type f -exec sh -c '
+              for candidate do
+                if file "$candidate" 2>/dev/null | grep -q "Mach-O"; then
+                  chmod +x "$candidate" 2>/dev/null || true
+                fi
+              done
+            ' sh {} +
+
+            find "$TARGET" -path "*/flutter_assets/assets/engine/*" -type f -exec sh -c '
+              for candidate do
+                if file "$candidate" 2>/dev/null | grep -q "Mach-O"; then
+                  chmod +x "$candidate" 2>/dev/null || true
+                fi
+              done
+            ' sh {} +
+          else
+            chmod +x "$TARGET"/Frameworks/*.framework/Versions/*/* 2>/dev/null || true
+            chmod +x "$TARGET"/Frameworks/App.framework/Versions/A/Resources/flutter_assets/assets/engine/macos/* 2>/dev/null || true
+          fi
+        }
+
+        restore_execute_bits
+
         if [ "$SKIP_RELAUNCH" != "1" ]; then
           open -n "$BUNDLE"
         fi


### PR DESCRIPTION
## Summary

This fixes a macOS update failure where the app closes during `installUpdate`, the staged files are copied into `YourApp.app/Contents`, but the app does not relaunch because copied executable files can lose their execute bit.

The helper now restores executable permissions after copying the staged update and before calling `open -n "$BUNDLE"`.

## What this covers

- `Contents/MacOS/*`, including the app's main executable
- Mach-O files inside `Contents/Frameworks`
- Mach-O files under bundled Flutter asset engines such as `flutter_assets/assets/engine/...`

## Reproduction / observed failure

In a real notarized Flutter macOS app using `desktop_updater 2.0.0-dev.1`, an update from an older build to a newer build successfully downloaded and copied the changed files, but relaunch failed with macOS showing:

> The application “Example.app” can’t be opened.

Inspection showed the updated bundle metadata and signature were valid, but the main executable had been copied as a regular non-executable file:

```text
-rw-r--r-- ... /Applications/Example.app/Contents/MacOS/example
```

`open -n /Applications/Example.app` then failed with launchd spawn failure. Reinstalling the same signed DMG produced the expected mode:

```text
-rwxr-xr-x ... /Applications/Example.app/Contents/MacOS/example
```

The updater's staging/download path writes files as regular files, so permission bits from the original app bundle are not guaranteed to survive the delta install.

## Testing

- `flutter test`
- Manually ran the generated shell logic against copied Mach-O payloads with mode `0644` and verified it restored `0755` before relaunch.
