### PR TITLE
Fix flutter build process on Windows + stream output in real-time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 2.1.2
 
+* Fixed Windows `release publish` builds so the CLI invokes `flutter build windows --release` through shell-aware process resolution.
 * Fixed notarized macOS `release publish` so nested Flutter frameworks are signed before the outer `.app`, then verified through notary, stapler, and Gatekeeper before packaging.
 * Added user-facing `release publish` smoke coverage for Windows, Linux, and opt-in notarized macOS CI so release smoke tests exercise the same publish command users run.
 

--- a/lib/src/release_cli/release_publisher.dart
+++ b/lib/src/release_cli/release_publisher.dart
@@ -1,3 +1,4 @@
+import "dart:convert";
 import "dart:io";
 
 import "package:desktop_updater/src/core/release_index.dart";
@@ -232,17 +233,24 @@ Future<void> _build(
   StringSink output,
 ) async {
   output.writeln("Building ${metadata.platform} release...");
-  final result = await Process.run(
+  final process = await Process.start(
     "flutter",
     metadata.profile.flutterBuildArgs,
     workingDirectory: projectRoot.path,
+    runInShell: true,
   );
-  if (result.exitCode != 0) {
+
+  process.stdout.transform(utf8.decoder).listen(output.write);
+  process.stderr.transform(utf8.decoder).listen(output.write);
+
+  final exitCode = await process.exitCode;
+
+  if (exitCode != 0) {
     throw ProcessException(
       "flutter",
       metadata.profile.flutterBuildArgs,
-      "${result.stdout}\n${result.stderr}",
-      result.exitCode,
+      "Build failed with exit code $exitCode",
+      exitCode,
     );
   }
 }

--- a/lib/src/release_cli/release_publisher.dart
+++ b/lib/src/release_cli/release_publisher.dart
@@ -19,18 +19,58 @@ import "package:desktop_updater/src/release_cli/upload/upload_provider.dart";
 import "package:desktop_updater/src/release_cli/validate_command.dart";
 import "package:path/path.dart" as path;
 
+/// Starts the Flutter build subprocess used by `release publish`.
+typedef BuildProcessStarter = Future<BuildProcess> Function(
+  String executable,
+  List<String> arguments, {
+  String? workingDirectory,
+  bool runInShell,
+});
+
+/// A started build subprocess.
+abstract interface class BuildProcess {
+  /// The process standard output stream.
+  Stream<List<int>> get stdout;
+
+  /// The process standard error stream.
+  Stream<List<int>> get stderr;
+
+  /// Completes with the process exit code.
+  Future<int> get exitCode;
+}
+
+/// Adapter for a real `dart:io` process.
+class StartedBuildProcess implements BuildProcess {
+  /// Creates an adapter for [process].
+  const StartedBuildProcess(this.process);
+
+  /// The underlying process.
+  final Process process;
+
+  @override
+  Stream<List<int>> get stdout => process.stdout;
+
+  @override
+  Stream<List<int>> get stderr => process.stderr;
+
+  @override
+  Future<int> get exitCode => process.exitCode;
+}
+
 class ReleasePublisher {
   const ReleasePublisher({
     this.skipBuild = false,
     this.packager = const ZipReleasePackager(),
     this.metadataResolver = const ProjectMetadataResolver(),
     this.runProcess = defaultProcessRunner,
-  });
+    BuildProcessStarter startBuildProcess = defaultBuildProcessStarter,
+  }) : _startBuildProcess = startBuildProcess;
 
   final bool skipBuild;
   final ReleasePackager packager;
   final ProjectMetadataResolver metadataResolver;
   final ProcessRunner runProcess;
+  final BuildProcessStarter _startBuildProcess;
 
   Future<PublishManifest> publish({
     required Directory projectRoot,
@@ -54,7 +94,7 @@ class ReleasePublisher {
     );
 
     if (!skipBuild) {
-      await _build(projectRoot, metadata, output);
+      await _build(projectRoot, metadata, output, _startBuildProcess);
     }
 
     if (platform == "macos" && config.macos.notarize) {
@@ -317,19 +357,24 @@ Future<void> _build(
   Directory projectRoot,
   ProjectMetadata metadata,
   StringSink output,
+  BuildProcessStarter startBuildProcess,
 ) async {
   output.writeln("Building ${metadata.platform} release...");
-  final process = await Process.start(
+  final process = await startBuildProcess(
     "flutter",
     metadata.profile.flutterBuildArgs,
     workingDirectory: projectRoot.path,
-    runInShell: true,
+    runInShell: _shouldRunFlutterBuildInShell(metadata.platform),
   );
 
-  process.stdout.transform(utf8.decoder).listen(output.write);
-  process.stderr.transform(utf8.decoder).listen(output.write);
-
+  final stdoutDone = process.stdout.transform(utf8.decoder).forEach(
+        output.write,
+      );
+  final stderrDone = process.stderr.transform(utf8.decoder).forEach(
+        output.write,
+      );
   final exitCode = await process.exitCode;
+  await Future.wait([stdoutDone, stderrDone]);
 
   if (exitCode != 0) {
     throw ProcessException(
@@ -339,6 +384,27 @@ Future<void> _build(
       exitCode,
     );
   }
+}
+
+/// Default Flutter build process starter.
+Future<BuildProcess> defaultBuildProcessStarter(
+  String executable,
+  List<String> arguments, {
+  String? workingDirectory,
+  bool runInShell = false,
+}) async {
+  return StartedBuildProcess(
+    await Process.start(
+      executable,
+      arguments,
+      workingDirectory: workingDirectory,
+      runInShell: runInShell,
+    ),
+  );
+}
+
+bool _shouldRunFlutterBuildInShell(String platform) {
+  return platform == "windows";
 }
 
 Future<ProcessResult> _runChecked(

--- a/test/release_cli/release_publisher_build_test.dart
+++ b/test/release_cli/release_publisher_build_test.dart
@@ -1,0 +1,210 @@
+import "dart:convert";
+import "dart:io";
+
+import "package:desktop_updater/src/core/release_descriptor.dart";
+import "package:desktop_updater/src/package/release_packager.dart";
+import "package:desktop_updater/src/release_cli/release_publish_config.dart";
+import "package:desktop_updater/src/release_cli/release_publisher.dart";
+import "package:flutter_test/flutter_test.dart";
+import "package:path/path.dart" as path;
+
+void main() {
+  test("windows publish build uses shell-aware flutter process", () async {
+    final root = await _createWindowsFixture();
+    final commands = <String>[];
+    final buildCalls = <_BuildProcessCall>[];
+    final packager = _RecordingPackager(commands);
+    final output = StringBuffer();
+    try {
+      final publisher = ReleasePublisher(
+        packager: packager,
+        startBuildProcess: (
+          executable,
+          arguments, {
+          workingDirectory,
+          runInShell = false,
+        }) async {
+          buildCalls.add(
+            _BuildProcessCall(
+              executable: executable,
+              arguments: arguments,
+              workingDirectory: workingDirectory,
+              runInShell: runInShell,
+            ),
+          );
+          return const _FakeBuildProcess(
+            stdoutText: "build stdout\n",
+            stderrText: "build stderr\n",
+          );
+        },
+      );
+
+      await publisher.publish(
+        projectRoot: root,
+        platform: "windows",
+        overrides: const ReleasePublishOverrides(),
+        output: output,
+      );
+
+      expect(buildCalls, hasLength(1));
+      final call = buildCalls.single;
+      expect(call.executable, "flutter");
+      expect(call.arguments, ["build", "windows", "--release"]);
+      expect(call.workingDirectory, root.path);
+      expect(call.runInShell, isTrue);
+      expect(output.toString(), contains("build stdout"));
+      expect(output.toString(), contains("build stderr"));
+      expect(commands.single, startsWith("PACKAGE "));
+    } finally {
+      await root.delete(recursive: true);
+    }
+  });
+
+  for (final platform in ["linux", "macos"]) {
+    test("$platform publish build does not force shell resolution", () async {
+      final root = await _createFixture(platform);
+      final commands = <String>[];
+      final buildCalls = <_BuildProcessCall>[];
+      final packager = _RecordingPackager(commands);
+      try {
+        final publisher = ReleasePublisher(
+          packager: packager,
+          startBuildProcess: (
+            executable,
+            arguments, {
+            workingDirectory,
+            runInShell = false,
+          }) async {
+            buildCalls.add(
+              _BuildProcessCall(
+                executable: executable,
+                arguments: arguments,
+                workingDirectory: workingDirectory,
+                runInShell: runInShell,
+              ),
+            );
+            return const _FakeBuildProcess();
+          },
+        );
+
+        await publisher.publish(
+          projectRoot: root,
+          platform: platform,
+          overrides: const ReleasePublishOverrides(
+            packageId: "com.example.egasManager",
+          ),
+          output: StringBuffer(),
+        );
+
+        expect(buildCalls, hasLength(1));
+        final call = buildCalls.single;
+        expect(call.executable, "flutter");
+        expect(call.arguments, ["build", platform, "--release"]);
+        expect(call.workingDirectory, root.path);
+        expect(call.runInShell, isFalse);
+        expect(commands.single, startsWith("PACKAGE "));
+      } finally {
+        await root.delete(recursive: true);
+      }
+    });
+  }
+}
+
+Future<Directory> _createWindowsFixture() async {
+  return _createFixture("windows");
+}
+
+Future<Directory> _createFixture(String platform) async {
+  final root = await Directory.systemTemp.createTemp("publish_build_");
+  await File(path.join(root.path, "pubspec.yaml")).writeAsString("""
+name: egas_manager
+version: 2.1.0
+""");
+  await File(path.join(root.path, "desktop_updater.yaml")).writeAsString("""
+updates:
+  baseUrl: https://updates.example.com
+""");
+  if (platform == "linux") {
+    final linux = Directory(path.join(root.path, "linux"));
+    await linux.create(recursive: true);
+    await File(path.join(linux.path, "CMakeLists.txt")).writeAsString("""
+set(APPLICATION_ID "com.example.egasManager")
+""");
+  }
+  return root;
+}
+
+class _BuildProcessCall {
+  const _BuildProcessCall({
+    required this.executable,
+    required this.arguments,
+    required this.workingDirectory,
+    required this.runInShell,
+  });
+
+  final String executable;
+  final List<String> arguments;
+  final String? workingDirectory;
+  final bool runInShell;
+}
+
+class _FakeBuildProcess implements BuildProcess {
+  const _FakeBuildProcess({
+    this.stdoutText = "",
+    this.stderrText = "",
+  });
+
+  final String stdoutText;
+  final String stderrText;
+
+  @override
+  Stream<List<int>> get stdout => Stream.value(utf8.encode(stdoutText));
+
+  @override
+  Stream<List<int>> get stderr => Stream.value(utf8.encode(stderrText));
+
+  @override
+  Future<int> get exitCode async => 0;
+}
+
+class _RecordingPackager implements ReleasePackager {
+  _RecordingPackager(this.commands);
+
+  final List<String> commands;
+
+  @override
+  Future<ReleasePackageResult> package(ReleasePackageRequest request) async {
+    commands.add("PACKAGE ${request.input.path}");
+    await request.outputDirectory.create(recursive: true);
+    final artifact = File(
+      path.join(request.outputDirectory.path, "Egas-Manager-2.1.0-windows.zip"),
+    );
+    await artifact.writeAsString("zip");
+    final release =
+        File(path.join(request.outputDirectory.path, "release.json"));
+    final descriptor = ReleaseDescriptor(
+      schemaVersion: 3,
+      packageId: request.packageId,
+      appName: request.appName,
+      version: request.version,
+      buildNumber: request.buildNumber,
+      platform: request.platform,
+      channel: request.channel,
+      artifact: ReleaseArtifact(
+        kind: "zip",
+        url: request.artifactUrl,
+        sha256: "a" * 64,
+        length: await artifact.length(),
+      ),
+      install: ReleaseInstall(strategy: request.installStrategy),
+      minimumUpdaterVersion: request.minimumUpdaterVersion,
+      generatedAt: DateTime.utc(2026, 6, 12),
+    );
+    await release.writeAsString("{}");
+    return ReleasePackageResult(
+      artifact: artifact,
+      releaseFile: release,
+      descriptor: descriptor,
+    );
+  }
+}


### PR DESCRIPTION
### Problem

`Process.run('flutter', ...)` fails on Windows with:
```
ProcessException: The system cannot find the file specified
  Command: flutter build windows --release
```
This happens because `flutter` on Windows is a `.bat` file, which cannot be executed directly by Dart — it needs to be resolved through a shell.

### Changes

- Replaced `Process.run` with `Process.start` + `runInShell: true`
  - `runInShell: true` wraps the command in `cmd /c` on Windows, letting the shell resolve `flutter.bat` via PATH — exactly like running it from a terminal
- stdout and stderr are now streamed in real-time to `output` instead of being captured at the end

### Testing

Verified that `flutter build windows --release` now runs successfully when spawned from Dart on Windows.

Solve https://github.com/MarlonJD/flutter_desktop_updater/issues/47