### PR TITLE
Fix macOS update bundle metadata

### DIFF
--- a/lib/src/package/zip_release_packager.dart
+++ b/lib/src/package/zip_release_packager.dart
@@ -20,7 +20,7 @@ class ZipReleasePackager implements ReleasePackager {
     final artifact = File(
       path.join(
         request.outputDirectory.path,
-        "${request.appName}-${request.version}-${request.platform}.zip",
+        "${_artifactNameStem(request.appName)}-${request.version}-${request.platform}.zip",
       ),
     );
 
@@ -90,4 +90,15 @@ class ZipReleasePackager implements ReleasePackager {
       throw FileSystemException("Package input does not exist", input.path);
     }
   }
+}
+
+String _artifactNameStem(String appName) {
+  var stem = path.basename(appName);
+  if (stem.endsWith(".app")) {
+    stem = stem.substring(0, stem.length - ".app".length);
+  }
+  if (stem.endsWith(".exe")) {
+    stem = stem.substring(0, stem.length - ".exe".length);
+  }
+  return stem;
 }

--- a/lib/src/release_cli/release_publisher.dart
+++ b/lib/src/release_cli/release_publisher.dart
@@ -146,13 +146,13 @@ class ReleasePublisher {
     );
 
     output.writeln("Packaging update...");
-    final packageAppName = _artifactNameStem(metadata.appName);
+    final archiveAppName = _artifactNameStem(metadata.appName);
     final packageResult = await packager.package(
       ReleasePackageRequest(
         input: metadata.input,
         outputDirectory: layout.releaseDirectory,
         packageId: metadata.packageId,
-        appName: packageAppName,
+        appName: metadata.appName,
         version: metadata.version,
         buildNumber: metadata.buildNumber,
         platform: platform,
@@ -164,7 +164,7 @@ class ReleasePublisher {
 
     await upsertAppArchive(
       archiveFile: layout.appArchiveFile,
-      appName: packageAppName,
+      appName: archiveAppName,
       supportPolicy: overrides.minimumSupportedVersion == null
           ? null
           : ReleaseSupportPolicy(

--- a/test/release_cli/release_publisher_build_test.dart
+++ b/test/release_cli/release_publisher_build_test.dart
@@ -158,6 +158,35 @@ void main() {
     });
   }
 
+  test("macOS publish keeps .app bundle name in release descriptor", () async {
+    final root = await _createFixture("macos");
+    final commands = <String>[];
+    final packager = _RecordingPackager(commands);
+    try {
+      final publisher = ReleasePublisher(
+        skipBuild: true,
+        packager: packager,
+      );
+
+      await publisher.publish(
+        projectRoot: root,
+        platform: "macos",
+        overrides: const ReleasePublishOverrides(),
+        output: StringBuffer(),
+      );
+
+      expect(packager.requests, hasLength(1));
+      expect(packager.requests.single.appName, "Egas Manager.app");
+      expect(
+        packager.requests.single.artifactUrl.toString(),
+        "https://updates.example.com/releases/2.1.0/macos/"
+        "Egas%20Manager-2.1.0-macos.zip",
+      );
+    } finally {
+      await root.delete(recursive: true);
+    }
+  });
+
   test("release hooks run around packaging with environment contract",
       () async {
     final root = await _createHookFixture();
@@ -305,9 +334,11 @@ class _RecordingPackager implements ReleasePackager {
   _RecordingPackager(this.commands);
 
   final List<String> commands;
+  final List<ReleasePackageRequest> requests = [];
 
   @override
   Future<ReleasePackageResult> package(ReleasePackageRequest request) async {
+    requests.add(request);
     commands.add("PACKAGE ${request.input.path}");
     await request.outputDirectory.create(recursive: true);
     final artifact = File(

--- a/test/zip_release_packager_test.dart
+++ b/test/zip_release_packager_test.dart
@@ -68,4 +68,45 @@ void main() {
       await tempDir.delete(recursive: true);
     }
   });
+
+  test("macOS zip artifact filename strips .app but descriptor keeps it",
+      () async {
+    final tempDir = await Directory.systemTemp.createTemp("packager_");
+    try {
+      final input = Directory(path.join(tempDir.path, "Example.app"));
+      await input.create();
+      File(path.join(input.path, "app.txt")).writeAsStringSync("hello");
+      final output = Directory(path.join(tempDir.path, "out"));
+
+      final dittoCalls = <List<String>>[];
+      final result = await ZipReleasePackager(
+        runProcess: (executable, arguments) async {
+          dittoCalls.add([executable, ...arguments]);
+          await File(arguments.last).writeAsString("zip");
+          return ProcessResult(0, 0, "", "");
+        },
+      ).package(
+        ReleasePackageRequest(
+          input: input,
+          outputDirectory: output,
+          packageId: "com.example.app",
+          appName: "Example.app",
+          version: "2.0.0",
+          platform: "macos",
+          channel: "stable",
+          artifactUrl: Uri.parse(
+            "https://cdn.example.com/Example-2.0.0-macos.zip",
+          ),
+          installStrategy: "wholeBundleReplace",
+        ),
+      );
+
+      expect(path.basename(result.artifact.path), "Example-2.0.0-macos.zip");
+      expect(result.descriptor.appName, "Example.app");
+      expect(dittoCalls, hasLength(1));
+      expect(dittoCalls.single.first, "/usr/bin/ditto");
+    } finally {
+      await tempDir.delete(recursive: true);
+    }
+  });
 }


### PR DESCRIPTION
## Summary
- Preserve the macOS .app bundle name in release metadata so staging looks for the extracted bundle directory.
- Keep generated artifact zip filenames extension-stripped to preserve the existing publish URL shape.
- Add regression coverage for release publish and zip packaging.

## Root cause
release publish reused the artifact filename stem as the descriptor appName, so macOS updates could look for a staged App directory instead of App.app.

## Validation
- flutter test --no-pub test/release_cli/release_publisher_build_test.dart test/zip_release_packager_test.dart test/release_cli/publish_layout_test.dart test/release_cli/macos_notarization_test.dart test/release_cli/project_metadata_resolver_test.dart
- flutter analyze --no-fatal-infos --no-pub (exit 0; existing info lints only)

Fixes #61