### PR TITLE
fix: support inno-compatible windows updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 2.4.5
+
+* Preserved Inno Setup uninstall artifacts named `unins###.exe`,
+  `unins###.dat`, and `unins###.msg` during Windows direct zip
+  `wholeDirectoryReplace` updates.
+* Retried Windows staging cleanup after a successful payload copy without
+  rolling back the already-installed update when cleanup still fails.
+* Added conservative Dart cleanup for old `desktop_updater_stage_*` directories
+  before creating a new staging directory.
+* Documented the Inno-compatible direct zip update boundary and clarified that
+  the updater still does not download or execute Inno `.exe` installers.
+
 ## 2.4.4
 
 * Fixed macOS `release publish` metadata so `release.json` preserves the

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Add the package:
 
 ```yaml
 dependencies:
-  desktop_updater: ^2.4.4
+  desktop_updater: ^2.4.5
 ```
 
 Point your app at the hosted archive:

--- a/docs/diagnostics-and-recovery.md
+++ b/docs/diagnostics-and-recovery.md
@@ -133,6 +133,18 @@ the user cancels the UAC prompt, the app remains open and `installUpdate`
 returns an `InstallError`; no post-exit helper log is written because the helper
 never starts.
 
+After a successful Windows copy, the helper retries staging cleanup for a short
+bounded window. The diagnostics log may include `cleanup retry` before
+`cleanup success` when antivirus, indexing, or another process temporarily
+holds a file. If cleanup still fails, the helper writes `cleanup failure` and
+continues to relaunch because the update has already been copied into place.
+
+Before staging a new update, the Dart update client removes old
+`desktop_updater_stage_*` directories from the staging parent when they are
+older than the bounded stale-staging window. Recent staging directories are left
+alone so a user who downloaded an update but has not installed it yet does not
+lose the staged update.
+
 ## Recovery Store
 
 `diagnosticsLogPath` tells you what happened inside the native helper. It does

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -1117,6 +1117,25 @@ What you should do for production trust:
 - Keep the app executable and package identity stable.
 - Test update install from a normal user account, not only an admin shell.
 
+For apps that were originally installed with Inno Setup, Windows direct zip
+updates preserve Inno uninstall artifacts named `unins###.exe`,
+`unins###.dat`, and `unins###.msg` in the app root. This keeps the existing
+Windows uninstall entry usable when the updater replaces the Flutter Release
+payload.
+
+This is Inno-compatible direct zip updating, not full Inno installer updating.
+The updater does not download or execute an Inno `.exe` installer, and it does
+not regenerate Inno's uninstall log. If a zip update adds new files that were
+not part of the original installer, Inno may leave those files behind during
+uninstall.
+
+A successful Windows install should remove its `desktop_updater_stage_*`
+directory after the payload copy succeeds. If the app downloads an update but
+the install is cancelled, never handed to the native helper, or fails before the
+successful copy point, a staging directory can remain temporarily. Future update
+checks prune stale staging directories conservatively after they age past the
+cleanup window.
+
 When the app is installed under a protected machine-wide directory such as
 `C:\Program Files`, the Windows helper treats that install root as requiring
 elevation when the current process is not already elevated. It also checks

--- a/docs/windows-linux-production-release.md
+++ b/docs/windows-linux-production-release.md
@@ -61,6 +61,21 @@ Notes:
 - SmartScreen reputation is separate from a valid signature. A new publisher or
   newly issued certificate can still see warnings until reputation builds.
 
+### Inno Setup Installed Apps
+
+`desktop_updater` can update an app that was originally installed with Inno
+Setup when the update artifact is still the normal Windows Release directory
+zip. During Windows `wholeDirectoryReplace`, the helper preserves Inno uninstall
+artifacts named `unins###.exe`, `unins###.dat`, and `unins###.msg` in the app
+root so the existing uninstall entry remains usable.
+
+This is not full Inno installer updating, and this compatibility path does not
+run an Inno installer. Use it when you want Inno for first install and
+`desktop_updater` for direct zip updates. If your update policy requires
+installer-owned repair, modify, uninstall-log, or enterprise deployment
+behavior, track that as installer-based update support instead of relying on
+direct zip updates.
+
 ### Windows Install Location And UAC
 
 Windows applies different write permissions depending on where the app is

--- a/lib/src/core/staging_directory_cleanup.dart
+++ b/lib/src/core/staging_directory_cleanup.dart
@@ -1,0 +1,85 @@
+import "dart:io";
+
+import "package:path/path.dart" as path;
+
+/// Prefix used for temporary staging directories created by the updater.
+const String desktopUpdaterStagingPrefix = "desktop_updater_stage_";
+
+/// Default age after which abandoned staging directories can be removed.
+const Duration defaultStaleStagingAge = Duration(days: 7);
+
+/// Summary of one stale staging directory cleanup pass.
+class StagingDirectoryCleanupReport {
+  /// Creates a cleanup report with scan, delete, and failure counts.
+  const StagingDirectoryCleanupReport({
+    required this.scanned,
+    required this.deleted,
+    required this.failedPaths,
+  });
+
+  /// Number of direct children scanned in the staging parent.
+  final int scanned;
+
+  /// Number of stale staging directories deleted.
+  final int deleted;
+
+  /// Staging directory paths that could not be deleted.
+  final List<String> failedPaths;
+}
+
+/// Removes old `desktop_updater_stage_*` directories from [parent].
+Future<StagingDirectoryCleanupReport>
+    cleanupStaleDesktopUpdaterStagingDirectories({
+  required Directory parent,
+  DateTime? now,
+  Duration staleAge = defaultStaleStagingAge,
+  Set<String> preservedPaths = const {},
+}) async {
+  if (!await parent.exists()) {
+    return const StagingDirectoryCleanupReport(
+      scanned: 0,
+      deleted: 0,
+      failedPaths: [],
+    );
+  }
+
+  final cutoff = (now ?? DateTime.now()).subtract(staleAge);
+  final normalizedPreservedPaths = preservedPaths
+      .map((value) => path.normalize(path.absolute(value)))
+      .toSet();
+  var scanned = 0;
+  var deleted = 0;
+  final failedPaths = <String>[];
+
+  await for (final entity in parent.list(followLinks: false)) {
+    scanned += 1;
+    if (entity is! Directory) {
+      continue;
+    }
+    if (!path.basename(entity.path).startsWith(desktopUpdaterStagingPrefix)) {
+      continue;
+    }
+
+    final normalizedPath = path.normalize(path.absolute(entity.path));
+    if (normalizedPreservedPaths.contains(normalizedPath)) {
+      continue;
+    }
+
+    try {
+      final modified = (await entity.stat()).modified;
+      if (!modified.isBefore(cutoff)) {
+        continue;
+      }
+      await entity.delete(recursive: true);
+      deleted += 1;
+    } on FileSystemException {
+      failedPaths.add(entity.path);
+    }
+  }
+
+  return StagingDirectoryCleanupReport(
+    scanned: scanned,
+    deleted: deleted,
+    failedPaths: List.unmodifiable(failedPaths),
+  );
+}

--- a/lib/src/core/update_client.dart
+++ b/lib/src/core/update_client.dart
@@ -6,6 +6,7 @@ import "package:desktop_updater/src/core/macos_staged_app_validator.dart";
 import "package:desktop_updater/src/core/release_descriptor.dart";
 import "package:desktop_updater/src/core/release_index.dart";
 import "package:desktop_updater/src/core/safe_zip_extractor.dart";
+import "package:desktop_updater/src/core/staging_directory_cleanup.dart";
 import "package:desktop_updater/src/core/update_telemetry.dart";
 import "package:desktop_updater/src/io/composite_update_transport.dart";
 import "package:desktop_updater/src/io/http_update_transport.dart"
@@ -143,8 +144,11 @@ class UpdateClient {
     await _verifier.verifyDescriptor(descriptor);
     _ensureDescriptorPolicyAllowsDownload(descriptor);
 
-    final stagingRoot = await (_stagingParent ?? Directory.systemTemp)
-        .createTemp("desktop_updater_stage_");
+    final stagingParent = _stagingParent ?? Directory.systemTemp;
+    await cleanupStaleDesktopUpdaterStagingDirectories(parent: stagingParent);
+    final stagingRoot = await stagingParent.createTemp(
+      desktopUpdaterStagingPrefix,
+    );
     final artifactFile = File(path.join(stagingRoot.path, "artifact.zip"));
 
     try {

--- a/lib/src/package_version.dart
+++ b/lib/src/package_version.dart
@@ -1,3 +1,3 @@
 /// Version of the `desktop_updater` package used in runtime policy checks and
 /// diagnostics reports.
-const String desktopUpdaterPackageVersion = "2.4.4";
+const String desktopUpdaterPackageVersion = "2.4.5";

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: desktop_updater
 description: "Sparkle-style auto-updates for Flutter desktop apps with verified releases, release CLI, built-in UI, and Windows/macOS/Linux support."
-version: 2.4.4
+version: 2.4.5
 homepage: https://github.com/MarlonJD/flutter_desktop_updater
 repository: https://github.com/MarlonJD/flutter_desktop_updater
 

--- a/test/e2e/zip_first_update_flow_test.dart
+++ b/test/e2e/zip_first_update_flow_test.dart
@@ -128,6 +128,49 @@ void main() {
     }
   });
 
+  test("removes stale staging directories before creating a new Windows stage",
+      () async {
+    final tempDir = await Directory.systemTemp.createTemp("zip_first_e2e_");
+    UpdateServer? server;
+    try {
+      final staleStage =
+          await Directory(path.join(tempDir.path, "desktop_updater_stage_old"))
+              .create();
+      await _setDirectoryLastModified(
+        staleStage,
+        DateTime.now().subtract(const Duration(days: 8)),
+      );
+
+      server = await UpdateServer.bind(tempDir);
+      await buildReleaseFixture(
+        root: tempDir,
+        baseUri: server.uri,
+        platform: "windows",
+      );
+
+      final client = UpdateClient(
+        appArchiveUrl: server.uri.resolve("app-archive.json"),
+        currentVersion: DesktopVersionInfo.fromParts(
+          versionName: "1.0.0",
+          buildNumber: "100",
+        ),
+        platform: "windows",
+        stagingParent: tempDir,
+      );
+      final check = await client.checkForUpdate();
+
+      final staged = await client.downloadVerifyAndStage(
+        descriptor: check!.descriptor,
+      );
+
+      expect(staleStage.existsSync(), isFalse);
+      expect(Directory(staged.stagingPath).existsSync(), isTrue);
+    } finally {
+      await server?.close();
+      await tempDir.delete(recursive: true);
+    }
+  });
+
   test("checksum mismatch fails before extraction", () async {
     final tempDir = await Directory.systemTemp.createTemp("zip_first_e2e_");
     UpdateServer? server;
@@ -189,4 +232,47 @@ void main() {
       await tempDir.delete(recursive: true);
     }
   });
+}
+
+Future<void> _setDirectoryLastModified(
+  Directory directory,
+  DateTime value,
+) async {
+  final result = Platform.isWindows
+      ? await _setDirectoryLastModifiedWithPowerShell(directory, value)
+      : await _setDirectoryLastModifiedWithTouch(directory, value);
+  if (result.exitCode != 0) {
+    fail(
+      "Unable to set last modified for ${directory.path}: "
+      "${result.stderr}${result.stdout}",
+    );
+  }
+}
+
+Future<ProcessResult> _setDirectoryLastModifiedWithPowerShell(
+  Directory directory,
+  DateTime value,
+) {
+  final escapedPath = directory.path.replaceAll("'", "''");
+  final timestamp = value.toUtc().toIso8601String();
+  return Process.run("powershell.exe", [
+    "-NoProfile",
+    "-Command",
+    "\$item = Get-Item -LiteralPath '$escapedPath'; "
+        "\$item.LastWriteTimeUtc = [DateTime]::Parse('$timestamp')",
+  ]);
+}
+
+Future<ProcessResult> _setDirectoryLastModifiedWithTouch(
+  Directory directory,
+  DateTime value,
+) {
+  final local = value.toLocal();
+  final timestamp = "${local.year.toString().padLeft(4, "0")}"
+      "${local.month.toString().padLeft(2, "0")}"
+      "${local.day.toString().padLeft(2, "0")}"
+      "${local.hour.toString().padLeft(2, "0")}"
+      "${local.minute.toString().padLeft(2, "0")}"
+      ".${local.second.toString().padLeft(2, "0")}";
+  return Process.run("touch", ["-t", timestamp, directory.path]);
 }

--- a/test/native_helper_diagnostics_docs_test.dart
+++ b/test/native_helper_diagnostics_docs_test.dart
@@ -48,6 +48,9 @@ void main() {
     expect(source, contains("one JSON object per line"));
     expect(source, contains("helper scheduled"));
     expect(source, contains("relaunch attempt"));
+    expect(source, contains("cleanup retry"));
+    expect(source, contains("desktop_updater_stage_*"));
+    expect(source, contains("stale-staging window"));
     expect(source, contains("does not include a logging backend"));
     expect(source, isNot(contains("docs/plans")));
   });
@@ -70,6 +73,9 @@ void main() {
     expect(source, contains("descriptor signing"));
     expect(source, contains("repository signing"));
     expect(source, contains("Default package behavior writes no files"));
+    expect(source, contains("Inno Setup"));
+    expect(source, contains("unins###.exe"));
+    expect(source, contains("not full Inno installer updating"));
   });
 
   test("package metadata and changelog agree on current version", () {

--- a/test/native_helper_script_test.dart
+++ b/test/native_helper_script_test.dart
@@ -146,6 +146,58 @@ void main() {
     expect(pruneIndex, lessThan(copyIndex));
   });
 
+  test("Windows helper preserves Inno uninstall artifacts during prune", () {
+    final source =
+        File("windows/desktop_updater_plugin.cpp").readAsStringSync();
+    const predicateSnippet = "function Test-InstallerOwnedWindowsFile";
+    const preserveCondition =
+        r"$_.PSIsContainer -or -not (Test-InstallerOwnedWindowsFile $_.Name)";
+    const preserveEvent = "preserve installer file";
+    const pruneSnippet = r"Get-ChildItem -LiteralPath $target -Force";
+    const copySnippet =
+        r"Copy-Item -LiteralPath $_.FullName -Destination $target -Recurse -Force";
+
+    final predicateIndex = source.indexOf(predicateSnippet);
+    final pruneIndex = source.indexOf(pruneSnippet);
+    final conditionIndex = source.indexOf(preserveCondition);
+    final eventIndex = source.indexOf(preserveEvent);
+    final copyIndex = source.indexOf(copySnippet);
+
+    expect(predicateIndex, isNonNegative);
+    expect(pruneIndex, isNonNegative);
+    expect(conditionIndex, isNonNegative);
+    expect(eventIndex, isNonNegative);
+    expect(copyIndex, isNonNegative);
+    expect(predicateIndex, lessThan(pruneIndex));
+    expect(pruneIndex, lessThan(copyIndex));
+    expect(conditionIndex, lessThan(copyIndex));
+  });
+
+  test("Windows helper retries staging cleanup after successful copy", () {
+    final source =
+        File("windows/desktop_updater_plugin.cpp").readAsStringSync();
+    const cleanupFunction = "function Remove-StagingDirectoryWithRetry";
+    const retryEvent = "Write-DiagnosticsEvent 'cleanup retry'";
+    const cleanupCall = r"Remove-StagingDirectoryWithRetry -Path $staging";
+    const moveSuccess = "Write-DiagnosticsEvent 'move success'";
+    const relaunchSnippet = r"Start-Process -FilePath $exe";
+
+    final functionIndex = source.indexOf(cleanupFunction);
+    final retryIndex = source.indexOf(retryEvent);
+    final moveSuccessIndex = source.indexOf(moveSuccess);
+    final cleanupCallIndex = source.indexOf(cleanupCall);
+    final relaunchIndex = source.indexOf(relaunchSnippet);
+
+    expect(functionIndex, isNonNegative);
+    expect(retryIndex, isNonNegative);
+    expect(moveSuccessIndex, isNonNegative);
+    expect(cleanupCallIndex, isNonNegative);
+    expect(relaunchIndex, isNonNegative);
+    expect(functionIndex, lessThan(moveSuccessIndex));
+    expect(moveSuccessIndex, lessThan(cleanupCallIndex));
+    expect(cleanupCallIndex, lessThan(relaunchIndex));
+  });
+
   test("Windows helper updates uninstall DisplayVersion after overlay", () {
     final source =
         File("windows/desktop_updater_plugin.cpp").readAsStringSync();

--- a/test/staging_directory_cleanup_test.dart
+++ b/test/staging_directory_cleanup_test.dart
@@ -1,0 +1,126 @@
+import "dart:io";
+
+import "package:desktop_updater/src/core/staging_directory_cleanup.dart";
+import "package:flutter_test/flutter_test.dart";
+import "package:path/path.dart" as path;
+
+void main() {
+  test("deletes only stale desktop updater staging directories", () async {
+    final root = await Directory.systemTemp.createTemp("staging_cleanup_");
+    try {
+      final oldStage =
+          await Directory(path.join(root.path, "desktop_updater_stage_old"))
+              .create();
+      final recentStage =
+          await Directory(path.join(root.path, "desktop_updater_stage_recent"))
+              .create();
+      final unrelated =
+          await Directory(path.join(root.path, "other_stage_old")).create();
+      final stageFile =
+          File(path.join(root.path, "desktop_updater_stage_file"));
+      await stageFile.writeAsString("not a directory");
+
+      final now = DateTime.utc(2026, 7, 7, 12);
+      await _setLastModified(
+        oldStage,
+        now.subtract(const Duration(days: 8)),
+      );
+      await _setLastModified(
+        recentStage,
+        now.subtract(const Duration(hours: 2)),
+      );
+      await _setLastModified(
+        unrelated,
+        now.subtract(const Duration(days: 8)),
+      );
+      await stageFile.setLastModified(now.subtract(const Duration(days: 8)));
+
+      final report = await cleanupStaleDesktopUpdaterStagingDirectories(
+        parent: root,
+        now: now,
+      );
+
+      expect(oldStage.existsSync(), isFalse);
+      expect(recentStage.existsSync(), isTrue);
+      expect(unrelated.existsSync(), isTrue);
+      expect(stageFile.existsSync(), isTrue);
+      expect(report.scanned, 4);
+      expect(report.deleted, 1);
+      expect(report.failedPaths, isEmpty);
+    } finally {
+      await root.delete(recursive: true);
+    }
+  });
+
+  test("preserves explicitly protected staging paths", () async {
+    final root = await Directory.systemTemp.createTemp("staging_cleanup_");
+    try {
+      final protectedStage =
+          await Directory(path.join(root.path, "desktop_updater_stage_keep"))
+              .create();
+      final now = DateTime.utc(2026, 7, 7, 12);
+      await _setLastModified(
+        protectedStage,
+        now.subtract(const Duration(days: 8)),
+      );
+
+      final report = await cleanupStaleDesktopUpdaterStagingDirectories(
+        parent: root,
+        now: now,
+        preservedPaths: {protectedStage.path},
+      );
+
+      expect(protectedStage.existsSync(), isTrue);
+      expect(report.scanned, 1);
+      expect(report.deleted, 0);
+      expect(report.failedPaths, isEmpty);
+    } finally {
+      await root.delete(recursive: true);
+    }
+  });
+}
+
+Future<void> _setLastModified(FileSystemEntity entity, DateTime value) async {
+  if (entity is File) {
+    await entity.setLastModified(value);
+    return;
+  }
+
+  final result = Platform.isWindows
+      ? await _setLastModifiedWithPowerShell(entity, value)
+      : await _setLastModifiedWithTouch(entity, value);
+  if (result.exitCode != 0) {
+    fail(
+      "Unable to set last modified for ${entity.path}: "
+      "${result.stderr}${result.stdout}",
+    );
+  }
+}
+
+Future<ProcessResult> _setLastModifiedWithPowerShell(
+  FileSystemEntity entity,
+  DateTime value,
+) {
+  final escapedPath = entity.path.replaceAll("'", "''");
+  final timestamp = value.toUtc().toIso8601String();
+  return Process.run("powershell.exe", [
+    "-NoProfile",
+    "-Command",
+    "\$item = Get-Item -LiteralPath '$escapedPath'; "
+        "\$item.LastWriteTimeUtc = [DateTime]::Parse('$timestamp')",
+  ]);
+}
+
+Future<ProcessResult> _setLastModifiedWithTouch(
+  FileSystemEntity entity,
+  DateTime value,
+) {
+  final local = value.toLocal();
+  final timestamp = "${local.year.toString().padLeft(4, "0")}"
+      "${local.month.toString().padLeft(2, "0")}"
+      "${local.day.toString().padLeft(2, "0")}"
+      "${local.hour.toString().padLeft(2, "0")}"
+      "${local.minute.toString().padLeft(2, "0")}"
+      ".${local.second.toString().padLeft(2, "0")}";
+  return Process.run("touch", ["-t", timestamp, entity.path]);
+}

--- a/windows/desktop_updater_plugin.cpp
+++ b/windows/desktop_updater_plugin.cpp
@@ -550,6 +550,33 @@ bool ScheduleInstallAndRelaunch(const std::wstring& staging_path,
       << "    }\n"
       << "  }\n"
       << "}\n"
+      << "function Test-InstallerOwnedWindowsFile([string]$Name) {\n"
+      << "  if ([string]::IsNullOrWhiteSpace($Name)) { return $false }\n"
+      << "  return $Name -imatch '^unins[0-9][0-9][0-9]\\.(exe|dat|msg)$'\n"
+      << "}\n"
+      << "function Remove-StagingDirectoryWithRetry([string]$Path) {\n"
+      << "  if ([string]::IsNullOrWhiteSpace($Path)) { return }\n"
+      << "  Write-DiagnosticsEvent 'cleanup start'\n"
+      << "  if (-not (Test-Path -LiteralPath $Path)) {\n"
+      << "    Write-DiagnosticsEvent 'cleanup success'\n"
+      << "    return\n"
+      << "  }\n"
+      << "  $cleanupDeadline = (Get-Date).AddSeconds(30)\n"
+      << "  while ($true) {\n"
+      << "    try {\n"
+      << "      Remove-Item -LiteralPath $Path -Recurse -Force -ErrorAction Stop\n"
+      << "      Write-DiagnosticsEvent 'cleanup success'\n"
+      << "      return\n"
+      << "    } catch {\n"
+      << "      if ((Get-Date) -gt $cleanupDeadline) {\n"
+      << "        Write-DiagnosticsEvent 'cleanup failure'\n"
+      << "        return\n"
+      << "      }\n"
+      << "      Write-DiagnosticsEvent 'cleanup retry'\n"
+      << "      Start-Sleep -Milliseconds 500\n"
+      << "    }\n"
+      << "  }\n"
+      << "}\n"
       << "$backup = Join-Path ([IO.Path]::GetTempPath()) "
          "('desktop_updater_backup_' + $pidToWait)\n"
       << "if (Test-Path -LiteralPath $backup) { "
@@ -583,7 +610,11 @@ bool ScheduleInstallAndRelaunch(const std::wstring& staging_path,
       << "    try {\n"
       << "      Write-DiagnosticsEvent 'move start'\n"
       << "      Get-ChildItem -LiteralPath $target -Force | ForEach-Object {\n"
-      << "        Remove-Item -LiteralPath $_.FullName -Recurse -Force\n"
+      << "        if ($_.PSIsContainer -or -not (Test-InstallerOwnedWindowsFile $_.Name)) {\n"
+      << "          Remove-Item -LiteralPath $_.FullName -Recurse -Force\n"
+      << "        } else {\n"
+      << "          Write-DiagnosticsEvent ('preserve installer file ' + $_.Name)\n"
+      << "        }\n"
       << "      }\n"
       << "      Get-ChildItem -LiteralPath $staging -Force | ForEach-Object {\n"
       << "        Copy-Item -LiteralPath $_.FullName -Destination $target -Recurse -Force\n"
@@ -610,13 +641,7 @@ bool ScheduleInstallAndRelaunch(const std::wstring& staging_path,
       << "      Start-Sleep -Seconds 1\n"
       << "    }\n"
       << "  }\n"
-      << "  Write-DiagnosticsEvent 'cleanup start'\n"
-      << "  try {\n"
-      << "    Remove-Item -LiteralPath $staging -Recurse -Force -ErrorAction Stop\n"
-      << "    Write-DiagnosticsEvent 'cleanup success'\n"
-      << "  } catch {\n"
-      << "    Write-DiagnosticsEvent 'cleanup failure'\n"
-      << "  }\n"
+      << "  Remove-StagingDirectoryWithRetry -Path $staging\n"
       << "}\n"
       << "Remove-Item -LiteralPath $backup -Recurse -Force -ErrorAction SilentlyContinue\n"
       << "} catch {\n"
@@ -787,6 +812,38 @@ bool IsKnownProtectedInstallDirectoryForTesting(
     }
   }
   return false;
+}
+
+bool IsInstallerOwnedWindowsFileForTesting(const std::wstring& file_name) {
+  const std::wstring name = fs::path(file_name).filename().wstring();
+  if (name.empty()) {
+    return false;
+  }
+
+  const size_t dot_position = name.rfind(L'.');
+  if (dot_position == std::wstring::npos) {
+    return false;
+  }
+
+  const std::wstring stem = name.substr(0, dot_position);
+  const std::wstring extension = name.substr(dot_position);
+  if (stem.size() != 8) {
+    return false;
+  }
+
+  if (_wcsnicmp(stem.c_str(), L"unins", 5) != 0) {
+    return false;
+  }
+
+  for (size_t index = 5; index < stem.size(); index += 1) {
+    if (stem[index] < L'0' || stem[index] > L'9') {
+      return false;
+    }
+  }
+
+  return _wcsicmp(extension.c_str(), L".exe") == 0 ||
+         _wcsicmp(extension.c_str(), L".dat") == 0 ||
+         _wcsicmp(extension.c_str(), L".msg") == 0;
 }
 
 // static

--- a/windows/desktop_updater_plugin.h
+++ b/windows/desktop_updater_plugin.h
@@ -27,6 +27,8 @@ bool IsKnownProtectedInstallDirectoryForTesting(
     const std::wstring& directory,
     const std::vector<std::wstring>& protected_roots);
 
+bool IsInstallerOwnedWindowsFileForTesting(const std::wstring& file_name);
+
 class DesktopUpdaterPlugin : public flutter::Plugin {
  public:
   static void RegisterWithRegistrar(flutter::PluginRegistrarWindows *registrar);

--- a/windows/test/desktop_updater_plugin_test.cpp
+++ b/windows/test/desktop_updater_plugin_test.cpp
@@ -52,6 +52,22 @@ TEST(DesktopUpdaterPlugin, RemovedFileMustBeStrictChildPath) {
   EXPECT_FALSE(IsStrictChildPathForTesting(L"C:\\App", L"C:\\Other\\data.txt"));
 }
 
+TEST(DesktopUpdaterPlugin, InnoUninstallArtifactsAreInstallerOwnedFiles) {
+  EXPECT_TRUE(IsInstallerOwnedWindowsFileForTesting(L"unins000.exe"));
+  EXPECT_TRUE(IsInstallerOwnedWindowsFileForTesting(L"unins000.dat"));
+  EXPECT_TRUE(IsInstallerOwnedWindowsFileForTesting(L"unins000.msg"));
+  EXPECT_TRUE(IsInstallerOwnedWindowsFileForTesting(L"UNINS001.EXE"));
+  EXPECT_TRUE(IsInstallerOwnedWindowsFileForTesting(
+      L"C:\\Program Files\\Example\\unins002.dat"));
+
+  EXPECT_FALSE(IsInstallerOwnedWindowsFileForTesting(L"unins.exe"));
+  EXPECT_FALSE(IsInstallerOwnedWindowsFileForTesting(L"unins00.exe"));
+  EXPECT_FALSE(IsInstallerOwnedWindowsFileForTesting(L"unins000.tmp"));
+  EXPECT_FALSE(IsInstallerOwnedWindowsFileForTesting(L"uninstall.exe"));
+  EXPECT_FALSE(IsInstallerOwnedWindowsFileForTesting(L"example.exe"));
+  EXPECT_FALSE(IsInstallerOwnedWindowsFileForTesting(L""));
+}
+
 TEST(DesktopUpdaterPlugin, ProgramFilesInstallDirectoryIsProtected) {
   const std::vector<std::wstring> protected_roots = {
       L"C:\\Program Files",


### PR DESCRIPTION
## Summary

Adds the Windows direct-zip compatibility path for apps originally installed with Inno Setup, without adding full Inno `.exe` installer execution.

- Preserve Inno uninstall artifacts named `unins###.exe`, `unins###.dat`, and `unins###.msg` during Windows `wholeDirectoryReplace` pruning.
- Retry Windows staging cleanup after a successful payload copy without rolling back an already-copied update when cleanup still fails.
- Prune stale `desktop_updater_stage_*` directories conservatively before future staging attempts.
- Bump the package to `2.4.5` and document the Inno-compatible direct zip update boundary.

## Validation

- `dart format --set-exit-if-changed .`
- `flutter test --no-pub test/native_helper_script_test.dart test/native_helper_diagnostics_docs_test.dart test/staging_directory_cleanup_test.dart test/e2e/zip_first_update_flow_test.dart`
- `flutter test --no-pub`
- `dart pub publish --dry-run` from a clean commit export

Windows native build, `ctest`, and update smoke validation are not run locally on this macOS host.
