### PR TITLE
feat: implement legacy ftp lease index publish

### DIFF
--- a/.github/workflows/desktop-updater-ci.yml
+++ b/.github/workflows/desktop-updater-ci.yml
@@ -196,6 +196,17 @@ jobs:
           set -euo pipefail
           mapfile -t files < <(printf '%s' "$TEST_FILES" | sed '/^$/d')
           flutter test --no-pub "${files[@]}"
+      - name: Test FTP release publish end to end
+        if: needs.changes.outputs.full == 'true' || needs.changes.outputs.cli == 'true'
+        env:
+          DESKTOP_UPDATER_RUN_RELEASE_PUBLISH_E2E: "1"
+          DESKTOP_UPDATER_FTP_PASSWORD: desktop-updater-test
+        shell: bash
+        run: |
+          set -euo pipefail
+          trap 'docker compose -f test/e2e/docker/docker-compose.release-publish.yml down -v' EXIT
+          docker info >/dev/null
+          flutter test --no-pub test/e2e/release_publish_ftp_e2e_test.dart
       - name: Check CLI entrypoints
         if: needs.changes.outputs.full == 'true' || needs.changes.outputs.cli == 'true'
         run: |

--- a/lib/src/release_cli/upload/ftp_upload_provider.dart
+++ b/lib/src/release_cli/upload/ftp_upload_provider.dart
@@ -1,11 +1,15 @@
+import "dart:convert";
 import "dart:io";
 
+import "package:crypto/crypto.dart";
 import "package:desktop_updater/src/release_cli/publish_manifest.dart";
 import "package:desktop_updater/src/release_cli/release_publish_config.dart";
 import "package:desktop_updater/src/release_cli/upload/upload_provider.dart";
 import "package:path/path.dart" as path;
 
+/// Writes release files to an FTP-backed update host.
 abstract interface class FtpRemoteFileClient {
+  /// Writes one non-index release file to [remotePath].
   Future<void> writeFile({
     required File file,
     required String remotePath,
@@ -13,8 +17,55 @@ abstract interface class FtpRemoteFileClient {
   });
 }
 
+/// Performs the FTP operations needed by [CurlFtpRemoteFileClient].
+///
+/// This is the internal seam for testing the lease protocol without making
+/// network calls. The default implementation delegates to the system curl
+/// executable.
+abstract interface class FtpRemoteOperations {
+  /// Uploads [file] to [remotePath].
+  Future<void> upload(
+    File file,
+    String remotePath,
+    FtpUploadConfig config,
+  );
+
+  /// Reads [remotePath], or returns null when the remote file is absent.
+  Future<List<int>?> read(
+    String remotePath,
+    FtpUploadConfig config,
+  );
+
+  /// Atomically claims [remotePath] as an exclusive lease directory.
+  Future<void> makeDirectory(
+    String remotePath,
+    FtpUploadConfig config,
+  );
+
+  /// Releases a previously claimed lease directory.
+  Future<void> removeDirectory(
+    String remotePath,
+    FtpUploadConfig config,
+  );
+
+  /// Removes a temporary remote file.
+  Future<void> removeFile(
+    String remotePath,
+    FtpUploadConfig config,
+  );
+
+  /// Renames [from] to [to] on the FTP host.
+  Future<void> rename(
+    String from,
+    String to,
+    FtpUploadConfig config,
+  );
+}
+
+/// Adds conditional index publication to [FtpRemoteFileClient].
 abstract interface class ExclusiveLeaseFtpRemoteFileClient
     implements FtpRemoteFileClient {
+  /// Publishes [file] after proving [expectedRevision] is still current.
   Future<IndexPublishReceipt> writeIndexFileWithLease({
     required File file,
     required String remotePath,
@@ -23,19 +74,27 @@ abstract interface class ExclusiveLeaseFtpRemoteFileClient
   });
 }
 
+/// Records one versioned FTP write for provider tests and diagnostics.
 class FtpRemoteWrite {
+  /// Creates a write record.
   const FtpRemoteWrite({
     required this.file,
     required this.remotePath,
   });
 
+  /// The local file that was written.
   final File file;
+
+  /// The remote path that received the file.
   final String remotePath;
 }
 
+/// Uploads versioned files before publishing the signed index over FTP.
 class FtpUploadProvider implements OrderedUploadProvider {
+  /// Creates an ordered FTP upload provider.
   const FtpUploadProvider({this.client = const CurlFtpRemoteFileClient()});
 
+  /// The adapter used to write files and publish the index.
   final FtpRemoteFileClient client;
 
   @override
@@ -111,8 +170,15 @@ class FtpUploadProvider implements OrderedUploadProvider {
   }
 }
 
-class CurlFtpRemoteFileClient implements FtpRemoteFileClient {
-  const CurlFtpRemoteFileClient();
+/// Implements ordered FTP publication using curl and an exclusive lease.
+class CurlFtpRemoteFileClient implements ExclusiveLeaseFtpRemoteFileClient {
+  /// Creates a curl-backed FTP client.
+  const CurlFtpRemoteFileClient({
+    this.operations = const CurlFtpRemoteOperations(),
+  });
+
+  /// The external FTP operations adapter.
+  final FtpRemoteOperations operations;
 
   @override
   Future<void> writeFile({
@@ -120,37 +186,269 @@ class CurlFtpRemoteFileClient implements FtpRemoteFileClient {
     required String remotePath,
     required FtpUploadConfig config,
   }) async {
-    final password = Platform.environment["DESKTOP_UPDATER_FTP_PASSWORD"];
-    if (password == null || password.isEmpty) {
-      throw StateError("Set DESKTOP_UPDATER_FTP_PASSWORD for FTP upload.");
-    }
+    await operations.upload(file, remotePath, config);
+  }
 
-    final tempDir =
-        await Directory.systemTemp.createTemp("desktop_updater_ftp_");
-    final curlConfig = File(path.join(tempDir.path, "curl.conf"));
+  @override
+  Future<IndexPublishReceipt> writeIndexFileWithLease({
+    required File file,
+    required String remotePath,
+    required FtpUploadConfig config,
+    required RemoteIndexRevision expectedRevision,
+  }) async {
+    final leasePath = _leasePath(remotePath);
+    final artifactName = path.posix.basename(remotePath);
+    final leaseToken = DateTime.now().microsecondsSinceEpoch.toString();
+    final temporaryPath = path.posix.join(
+      leasePath,
+      "$artifactName.$leaseToken.tmp",
+    );
+    final localSha256 = sha256.convert(await file.readAsBytes()).toString();
+
+    await operations.makeDirectory(leasePath, config);
+    var temporaryFileExists = false;
     try {
-      await curlConfig.writeAsString(
-        [
-          'url = "${_escapeCurlConfig(_remoteUri(config, remotePath).toString())}"',
-          'upload-file = "${_escapeCurlConfig(file.path)}"',
-          "ftp-create-dirs",
-          'user = "${_escapeCurlConfig("${config.username}:$password")}"',
-        ].join("\n"),
+      _assertExpectedRevision(
+        remotePath: remotePath,
+        expectedRevision: expectedRevision,
+        actualBytes: await operations.read(remotePath, config),
       );
-      final result = await Process.run("curl", ["--config", curlConfig.path]);
-      if (result.exitCode != 0) {
-        throw ProcessException(
-          "curl",
-          const ["--config", "<redacted>"],
-          "${result.stdout}\n${result.stderr}",
-          result.exitCode,
+
+      // An FTP server may leave a partial file behind even when the upload
+      // command reports an error. Mark it for cleanup before starting the
+      // transfer so a failed publication cannot strand a lease artifact.
+      temporaryFileExists = true;
+      await operations.upload(file, temporaryPath, config);
+
+      _assertExpectedRevision(
+        remotePath: remotePath,
+        expectedRevision: expectedRevision,
+        actualBytes: await operations.read(remotePath, config),
+      );
+      await operations.rename(temporaryPath, remotePath, config);
+      temporaryFileExists = false;
+
+      final publishedBytes = await operations.read(remotePath, config);
+      final publishedSha256 = publishedBytes == null
+          ? null
+          : sha256.convert(publishedBytes).toString();
+      if (publishedSha256 != localSha256) {
+        throw StateError(
+          "FTP index publish digest mismatch for $remotePath: "
+          "$publishedSha256 != $localSha256.",
         );
       }
+
+      return IndexPublishReceipt(
+        observedPriorRevision: expectedRevision,
+        publishedSha256: localSha256,
+        mechanism: IndexPublishMechanism.exclusiveLease,
+        leaseEvidenceSha256:
+            sha256.convert(utf8.encode("$leasePath|$leaseToken")).toString(),
+      );
+    } finally {
+      if (temporaryFileExists) {
+        await _bestEffort(() => operations.removeFile(temporaryPath, config));
+      }
+      await _bestEffort(() => operations.removeDirectory(leasePath, config));
+    }
+  }
+}
+
+/// Implements [FtpRemoteOperations] with the system curl executable.
+class CurlFtpRemoteOperations implements FtpRemoteOperations {
+  /// Creates a system-curl FTP operations adapter.
+  const CurlFtpRemoteOperations();
+
+  @override
+  Future<void> upload(
+    File file,
+    String remotePath,
+    FtpUploadConfig config,
+  ) async {
+    await _runCurl(
+      config,
+      [
+        'url = "${_escapeCurlConfig(_remoteUri(config, remotePath).toString())}"',
+        'upload-file = "${_escapeCurlConfig(file.path)}"',
+        "ftp-create-dirs",
+      ],
+    );
+  }
+
+  @override
+  Future<List<int>?> read(
+    String remotePath,
+    FtpUploadConfig config,
+  ) async {
+    final tempDir =
+        await Directory.systemTemp.createTemp("desktop_updater_ftp_read_");
+    final outputFile = File(path.join(tempDir.path, "remote-file"));
+    try {
+      final result = await _runCurl(
+        config,
+        [
+          'url = "${_escapeCurlConfig(_remoteUri(config, remotePath).toString())}"',
+          'output = "${_escapeCurlConfig(outputFile.path)}"',
+          "fail",
+        ],
+        tempDir: tempDir,
+      );
+      if (result.exitCode != 0) {
+        if (_isRemoteNotFound(result)) return null;
+        _throwCurlError(result);
+      }
+      return await outputFile.readAsBytes();
     } finally {
       if (await tempDir.exists()) {
         await tempDir.delete(recursive: true);
       }
     }
+  }
+
+  @override
+  Future<void> makeDirectory(
+    String remotePath,
+    FtpUploadConfig config,
+  ) async {
+    await _runFtpQuote(config, "MKD $remotePath");
+  }
+
+  @override
+  Future<void> removeDirectory(
+    String remotePath,
+    FtpUploadConfig config,
+  ) async {
+    await _runFtpQuote(config, "RMD $remotePath");
+  }
+
+  @override
+  Future<void> removeFile(
+    String remotePath,
+    FtpUploadConfig config,
+  ) async {
+    await _runFtpQuote(config, "DELE $remotePath");
+  }
+
+  @override
+  Future<void> rename(
+    String from,
+    String to,
+    FtpUploadConfig config,
+  ) async {
+    await _runFtpQuotes(config, ["RNFR $from", "RNTO $to"]);
+  }
+
+  Future<ProcessResult> _runFtpQuote(
+    FtpUploadConfig config,
+    String command,
+  ) {
+    return _runFtpQuotes(config, [command]);
+  }
+
+  Future<ProcessResult> _runFtpQuotes(
+    FtpUploadConfig config,
+    List<String> commands,
+  ) {
+    return _runCurl(
+      config,
+      [
+        'url = "${_escapeCurlConfig(_remoteUri(config, "/").toString())}"',
+        for (final command in commands)
+          'quote = "${_escapeCurlConfig(command)}"',
+      ],
+    );
+  }
+
+  Future<ProcessResult> _runCurl(
+    FtpUploadConfig config,
+    List<String> directives, {
+    Directory? tempDir,
+  }) async {
+    final password = Platform.environment["DESKTOP_UPDATER_FTP_PASSWORD"];
+    if (password == null || password.isEmpty) {
+      throw StateError("Set DESKTOP_UPDATER_FTP_PASSWORD for FTP upload.");
+    }
+
+    final ownsTempDir = tempDir == null;
+    final directory = tempDir ??
+        await Directory.systemTemp.createTemp("desktop_updater_ftp_");
+    final curlConfig = File(path.join(directory.path, "curl.conf"));
+    try {
+      await curlConfig.writeAsString(
+        [
+          ...directives,
+          'user = "${_escapeCurlConfig("${config.username}:$password")}"',
+        ].join("\n"),
+      );
+      final result = await Process.run("curl", ["--config", curlConfig.path]);
+      if (result.exitCode != 0 && !ownsTempDir) return result;
+      if (result.exitCode != 0) _throwCurlError(result);
+      return result;
+    } finally {
+      if (ownsTempDir && await directory.exists()) {
+        await directory.delete(recursive: true);
+      }
+    }
+  }
+
+  void _throwCurlError(ProcessResult result) {
+    throw ProcessException(
+      "curl",
+      const ["--config", "<redacted>"],
+      "${result.stdout}\n${result.stderr}",
+      result.exitCode,
+    );
+  }
+
+  bool _isRemoteNotFound(ProcessResult result) {
+    final output = "${result.stdout}\n${result.stderr}".toLowerCase();
+    return result.exitCode == 78 &&
+        (output.contains("550") ||
+            output.contains("not found") ||
+            output.contains("does not exist"));
+  }
+}
+
+void _assertExpectedRevision({
+  required String remotePath,
+  required RemoteIndexRevision expectedRevision,
+  required List<int>? actualBytes,
+}) {
+  if (expectedRevision.absent) {
+    if (actualBytes != null) {
+      throw StateError(
+        "FTP index changed before publish: expected $remotePath to be absent.",
+      );
+    }
+    return;
+  }
+  if (actualBytes == null) {
+    throw StateError(
+      "FTP index changed before publish: $remotePath is missing.",
+    );
+  }
+  final actualSha256 = sha256.convert(actualBytes).toString();
+  if (actualSha256 != expectedRevision.sha256) {
+    throw StateError(
+      "FTP index changed before publish: $actualSha256 != "
+      "${expectedRevision.sha256}.",
+    );
+  }
+}
+
+String _leasePath(String remotePath) {
+  final directory = path.posix.dirname(remotePath);
+  final fileName = path.posix.basename(remotePath);
+  return path.posix.join(directory, ".$fileName.desktop_updater.lock");
+}
+
+Future<void> _bestEffort(Future<void> Function() action) async {
+  try {
+    await action();
+  } on Object {
+    // Preserve the original publication failure and leave diagnostics to the
+    // caller. A stale lock is safer than an unverified index replacement.
   }
 }
 

--- a/lib/src/release_cli/upload/ftp_upload_provider.dart
+++ b/lib/src/release_cli/upload/ftp_upload_provider.dart
@@ -225,8 +225,18 @@ class CurlFtpRemoteFileClient implements ExclusiveLeaseFtpRemoteFileClient {
         expectedRevision: expectedRevision,
         actualBytes: await operations.read(remotePath, config),
       );
-      await operations.rename(temporaryPath, remotePath, config);
-      temporaryFileExists = false;
+      try {
+        await operations.rename(temporaryPath, remotePath, config);
+        temporaryFileExists = false;
+      } on Object {
+        // Some FTP servers refuse RNTO when the destination already exists
+        // (vsftpd answers 553 "Can't rename file."). Fall back to a direct
+        // overwrite upload of the fully-written index. The exclusive lease
+        // and the revision assertions above still guarantee the published
+        // bytes match the verified hosted history; the temporary file is
+        // removed by the cleanup below.
+        await operations.upload(file, remotePath, config);
+      }
 
       final publishedBytes = await operations.read(remotePath, config);
       final publishedSha256 = publishedBytes == null

--- a/lib/src/release_cli/upload/ftp_upload_provider.dart
+++ b/lib/src/release_cli/upload/ftp_upload_provider.dart
@@ -207,6 +207,7 @@ class CurlFtpRemoteFileClient implements ExclusiveLeaseFtpRemoteFileClient {
 
     await operations.makeDirectory(leasePath, config);
     var temporaryFileExists = false;
+    var publicationSucceeded = false;
     try {
       _assertExpectedRevision(
         remotePath: remotePath,
@@ -225,18 +226,8 @@ class CurlFtpRemoteFileClient implements ExclusiveLeaseFtpRemoteFileClient {
         expectedRevision: expectedRevision,
         actualBytes: await operations.read(remotePath, config),
       );
-      try {
-        await operations.rename(temporaryPath, remotePath, config);
-        temporaryFileExists = false;
-      } on Object {
-        // Some FTP servers refuse RNTO when the destination already exists
-        // (vsftpd answers 553 "Can't rename file."). Fall back to a direct
-        // overwrite upload of the fully-written index. The exclusive lease
-        // and the revision assertions above still guarantee the published
-        // bytes match the verified hosted history; the temporary file is
-        // removed by the cleanup below.
-        await operations.upload(file, remotePath, config);
-      }
+      await operations.rename(temporaryPath, remotePath, config);
+      temporaryFileExists = false;
 
       final publishedBytes = await operations.read(remotePath, config);
       final publishedSha256 = publishedBytes == null
@@ -249,18 +240,28 @@ class CurlFtpRemoteFileClient implements ExclusiveLeaseFtpRemoteFileClient {
         );
       }
 
-      return IndexPublishReceipt(
+      final receipt = IndexPublishReceipt(
         observedPriorRevision: expectedRevision,
         publishedSha256: localSha256,
         mechanism: IndexPublishMechanism.exclusiveLease,
         leaseEvidenceSha256:
             sha256.convert(utf8.encode("$leasePath|$leaseToken")).toString(),
       );
+      publicationSucceeded = true;
+      return receipt;
     } finally {
       if (temporaryFileExists) {
         await _bestEffort(() => operations.removeFile(temporaryPath, config));
       }
-      await _bestEffort(() => operations.removeDirectory(leasePath, config));
+      if (publicationSucceeded) {
+        await _releasePublishedLease(
+          operations: operations,
+          leasePath: leasePath,
+          config: config,
+        );
+      } else {
+        await _bestEffort(() => operations.removeDirectory(leasePath, config));
+      }
     }
   }
 }
@@ -321,7 +322,7 @@ class CurlFtpRemoteOperations implements FtpRemoteOperations {
     String remotePath,
     FtpUploadConfig config,
   ) async {
-    await _runFtpQuote(config, "MKD $remotePath");
+    await _runFtpQuote(config, "MKD ${_ftpQuotePath(remotePath)}");
   }
 
   @override
@@ -329,7 +330,7 @@ class CurlFtpRemoteOperations implements FtpRemoteOperations {
     String remotePath,
     FtpUploadConfig config,
   ) async {
-    await _runFtpQuote(config, "RMD $remotePath");
+    await _runFtpQuote(config, "RMD ${_ftpQuotePath(remotePath)}");
   }
 
   @override
@@ -337,7 +338,7 @@ class CurlFtpRemoteOperations implements FtpRemoteOperations {
     String remotePath,
     FtpUploadConfig config,
   ) async {
-    await _runFtpQuote(config, "DELE $remotePath");
+    await _runFtpQuote(config, "DELE ${_ftpQuotePath(remotePath)}");
   }
 
   @override
@@ -346,7 +347,10 @@ class CurlFtpRemoteOperations implements FtpRemoteOperations {
     String to,
     FtpUploadConfig config,
   ) async {
-    await _runFtpQuotes(config, ["RNFR $from", "RNTO $to"]);
+    await _runFtpQuotes(config, [
+      "RNFR ${_ftpQuotePath(from)}",
+      "RNTO ${_ftpQuotePath(to)}",
+    ]);
   }
 
   Future<ProcessResult> _runFtpQuote(
@@ -451,6 +455,26 @@ String _leasePath(String remotePath) {
   final directory = path.posix.dirname(remotePath);
   final fileName = path.posix.basename(remotePath);
   return path.posix.join(directory, ".$fileName.desktop_updater.lock");
+}
+
+String _ftpQuotePath(String remotePath) {
+  return remotePath.replaceFirst(RegExp(r"^/+"), "");
+}
+
+Future<void> _releasePublishedLease({
+  required FtpRemoteOperations operations,
+  required String leasePath,
+  required FtpUploadConfig config,
+}) async {
+  try {
+    await operations.removeDirectory(leasePath, config);
+  } on Object catch (error) {
+    throw StateError(
+      "FTP index was published, but the lease at $leasePath could not be "
+      "released. Remove the stale lease directory before publishing again. "
+      "Cleanup error: $error",
+    );
+  }
 }
 
 Future<void> _bestEffort(Future<void> Function() action) async {

--- a/test/e2e/docker/docker-compose.release-publish.yml
+++ b/test/e2e/docker/docker-compose.release-publish.yml
@@ -13,7 +13,6 @@ services:
 
   ftp:
     image: delfer/alpine-ftp-server:latest
-    platform: linux/arm64
     environment:
       USERS: deploy|desktop-updater-test|/ftp/deploy
       ADDRESS: 127.0.0.1

--- a/test/e2e/release_publish_e2e_helpers.dart
+++ b/test/e2e/release_publish_e2e_helpers.dart
@@ -299,7 +299,10 @@ bool get releasePublishE2eEnabled {
   return Platform.environment["DESKTOP_UPDATER_RUN_RELEASE_PUBLISH_E2E"] == "1";
 }
 
-Future<StringBuffer> publishFixture(ReleasePublishE2eFixture fixture) async {
+Future<StringBuffer> publishFixture(
+  ReleasePublishE2eFixture fixture, {
+  bool initializeFeed = true,
+}) async {
   final output = StringBuffer();
   final exitCode = await runReleaseCommand(
     [
@@ -307,7 +310,7 @@ Future<StringBuffer> publishFixture(ReleasePublishE2eFixture fixture) async {
       "--platform",
       fixture.platform,
       "--skip-build-for-test",
-      "--initialize-feed",
+      if (initializeFeed) "--initialize-feed",
     ],
     projectRoot: fixture.projectRoot,
     output: output,

--- a/test/e2e/release_publish_ftp_e2e_test.dart
+++ b/test/e2e/release_publish_ftp_e2e_test.dart
@@ -24,7 +24,7 @@ void main() {
     }
 
     await startDockerComposeServices(["ftp", "static"]);
-    await waitForPort(2121);
+    await waitForTcpPrefix(2121, "220");
     await waitForPort(8088);
     final fixture = await createReleasePublishE2eFixture(
       baseUrl: Uri.parse("http://127.0.0.1:8088/ftp/updates/"),

--- a/test/e2e/release_publish_ftp_e2e_test.dart
+++ b/test/e2e/release_publish_ftp_e2e_test.dart
@@ -38,8 +38,22 @@ ftp:
 """,
     );
     try {
-      final output = await publishFixture(fixture);
-      expect(output.toString(), contains("OK: Published and validated."));
+      final initialOutput = await publishFixture(fixture);
+      expect(
+        initialOutput.toString(),
+        contains("OK: Published and validated."),
+      );
+
+      // The second publication must recover the hosted history and use the
+      // normal revision-checked lease path without --initialize-feed.
+      final followUpOutput = await publishFixture(
+        fixture,
+        initializeFeed: false,
+      );
+      expect(
+        followUpOutput.toString(),
+        contains("OK: Published and validated."),
+      );
     } finally {
       await fixture.delete();
     }

--- a/test/release_cli/upload/ftp_upload_provider_test.dart
+++ b/test/release_cli/upload/ftp_upload_provider_test.dart
@@ -210,43 +210,137 @@ void main() {
     }
   });
 
-  test("default FTP client falls back to direct upload when rename fails",
-      () async {
+  test("default FTP client fails closed when rename fails", () async {
     final tempDir =
         await Directory.systemTemp.createTemp("ftp_rename_failure_");
     try {
       final index = File(path.join(tempDir.path, "app-archive.json"));
       await index.writeAsString("new index");
-      final operations = RecordingFtpRemoteOperations()..failRename = true;
+      final oldBytes = "old index".codeUnits;
+      final operations = RecordingFtpRemoteOperations()
+        ..files["/updates/app-archive.json"] = oldBytes
+        ..failRename = true;
       final client = CurlFtpRemoteFileClient(operations: operations);
 
-      final receipt = await client.writeIndexFileWithLease(
-        file: index,
-        remotePath: "/updates/app-archive.json",
-        config: const FtpUploadConfig(
-          host: "localhost",
-          remotePath: "/updates",
-          username: "deploy",
-          allowInsecure: true,
+      await expectLater(
+        client.writeIndexFileWithLease(
+          file: index,
+          remotePath: "/updates/app-archive.json",
+          config: const FtpUploadConfig(
+            host: "localhost",
+            remotePath: "/updates",
+            username: "deploy",
+            allowInsecure: true,
+          ),
+          expectedRevision: RemoteIndexRevision.present(
+            sha256: sha256.convert(oldBytes).toString(),
+            etag: null,
+          ),
         ),
-        expectedRevision: const RemoteIndexRevision.absent(),
+        throwsA(
+          isA<StateError>().having(
+            (error) => error.message,
+            "message",
+            contains("rename failed"),
+          ),
+        ),
       );
 
-      // The rename failed (simulating an FTP server that refuses RNTO onto an
-      // existing destination with 553), so the publisher must overwrite the
-      // final index with a direct upload and still verify the readback.
+      expect(
+        String.fromCharCodes(operations.files["/updates/app-archive.json"]!),
+        "old index",
+      );
+      expect(operations.directories, isEmpty);
+      expect(
+        operations.events.where((event) => event == "upload"),
+        hasLength(1),
+      );
+      expect(operations.events, contains("rename"));
+      expect(operations.events, contains("removeFile"));
+    } finally {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  test("default FTP client reports lease cleanup failure after publication",
+      () async {
+    final tempDir = await Directory.systemTemp.createTemp("ftp_cleanup_");
+    try {
+      final index = File(path.join(tempDir.path, "app-archive.json"));
+      await index.writeAsString("new index");
+      final operations = RecordingFtpRemoteOperations()
+        ..failRemoveDirectory = true;
+      final client = CurlFtpRemoteFileClient(operations: operations);
+      const leasePath = "/updates/.app-archive.json.desktop_updater.lock";
+
+      await expectLater(
+        client.writeIndexFileWithLease(
+          file: index,
+          remotePath: "/updates/app-archive.json",
+          config: const FtpUploadConfig(
+            host: "localhost",
+            remotePath: "/updates",
+            username: "deploy",
+            allowInsecure: true,
+          ),
+          expectedRevision: const RemoteIndexRevision.absent(),
+        ),
+        throwsA(
+          isA<StateError>()
+              .having(
+                (error) => error.message,
+                "message",
+                contains("FTP index was published"),
+              )
+              .having(
+                (error) => error.message,
+                "message",
+                contains(leasePath),
+              ),
+        ),
+      );
+
       expect(
         String.fromCharCodes(operations.files["/updates/app-archive.json"]!),
         "new index",
       );
-      expect(operations.directories, isEmpty);
-      expect(
-          operations.events.where((event) => event == "upload"), hasLength(2));
-      expect(operations.events, contains("rename"));
-      expect(operations.events, contains("removeFile"));
-      expect(receipt.mechanism, IndexPublishMechanism.exclusiveLease);
-      expect(receipt.publishedSha256,
-          sha256.convert(index.readAsBytesSync()).toString());
+      expect(operations.directories, contains(leasePath));
+    } finally {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  test("default FTP client preserves publish failure over cleanup failure",
+      () async {
+    final tempDir = await Directory.systemTemp.createTemp("ftp_dual_failure_");
+    try {
+      final index = File(path.join(tempDir.path, "app-archive.json"));
+      await index.writeAsString("new index");
+      final operations = RecordingFtpRemoteOperations()
+        ..failUpload = true
+        ..failRemoveDirectory = true;
+      final client = CurlFtpRemoteFileClient(operations: operations);
+
+      await expectLater(
+        client.writeIndexFileWithLease(
+          file: index,
+          remotePath: "/updates/app-archive.json",
+          config: const FtpUploadConfig(
+            host: "localhost",
+            remotePath: "/updates",
+            username: "deploy",
+            allowInsecure: true,
+          ),
+          expectedRevision: const RemoteIndexRevision.absent(),
+        ),
+        throwsA(
+          isA<StateError>().having(
+            (error) => error.message,
+            "message",
+            contains("upload failed"),
+          ),
+        ),
+      );
     } finally {
       await tempDir.delete(recursive: true);
     }
@@ -359,6 +453,7 @@ class RecordingFtpRemoteOperations implements FtpRemoteOperations {
   final events = <String>[];
   bool failUpload = false;
   bool failRename = false;
+  bool failRemoveDirectory = false;
   void Function()? afterUpload;
 
   @override
@@ -400,6 +495,7 @@ class RecordingFtpRemoteOperations implements FtpRemoteOperations {
     FtpUploadConfig config,
   ) async {
     events.add("removeDirectory");
+    if (failRemoveDirectory) throw StateError("remove directory failed");
     directories.remove(remotePath);
   }
 

--- a/test/release_cli/upload/ftp_upload_provider_test.dart
+++ b/test/release_cli/upload/ftp_upload_provider_test.dart
@@ -210,7 +210,8 @@ void main() {
     }
   });
 
-  test("default FTP client does not fall back when rename fails", () async {
+  test("default FTP client falls back to direct upload when rename fails",
+      () async {
     final tempDir =
         await Directory.systemTemp.createTemp("ftp_rename_failure_");
     try {
@@ -219,28 +220,33 @@ void main() {
       final operations = RecordingFtpRemoteOperations()..failRename = true;
       final client = CurlFtpRemoteFileClient(operations: operations);
 
-      await expectLater(
-        client.writeIndexFileWithLease(
-          file: index,
-          remotePath: "/updates/app-archive.json",
-          config: const FtpUploadConfig(
-            host: "localhost",
-            remotePath: "/updates",
-            username: "deploy",
-            allowInsecure: true,
-          ),
-          expectedRevision: const RemoteIndexRevision.absent(),
+      final receipt = await client.writeIndexFileWithLease(
+        file: index,
+        remotePath: "/updates/app-archive.json",
+        config: const FtpUploadConfig(
+          host: "localhost",
+          remotePath: "/updates",
+          username: "deploy",
+          allowInsecure: true,
         ),
-        throwsA(isA<StateError>().having(
-          (error) => error.message,
-          "message",
-          contains("rename failed"),
-        )),
+        expectedRevision: const RemoteIndexRevision.absent(),
       );
 
-      expect(operations.files, isEmpty);
+      // The rename failed (simulating an FTP server that refuses RNTO onto an
+      // existing destination with 553), so the publisher must overwrite the
+      // final index with a direct upload and still verify the readback.
+      expect(
+        String.fromCharCodes(operations.files["/updates/app-archive.json"]!),
+        "new index",
+      );
       expect(operations.directories, isEmpty);
+      expect(
+          operations.events.where((event) => event == "upload"), hasLength(2));
+      expect(operations.events, contains("rename"));
       expect(operations.events, contains("removeFile"));
+      expect(receipt.mechanism, IndexPublishMechanism.exclusiveLease);
+      expect(receipt.publishedSha256,
+          sha256.convert(index.readAsBytesSync()).toString());
     } finally {
       await tempDir.delete(recursive: true);
     }

--- a/test/release_cli/upload/ftp_upload_provider_test.dart
+++ b/test/release_cli/upload/ftp_upload_provider_test.dart
@@ -1,5 +1,6 @@
 import "dart:io";
 
+import "package:crypto/crypto.dart";
 import "package:desktop_updater/src/release_cli/publish_manifest.dart";
 import "package:desktop_updater/src/release_cli/release_publish_config.dart";
 import "package:desktop_updater/src/release_cli/upload/ftp_upload_provider.dart";
@@ -9,6 +10,242 @@ import "package:flutter_test/flutter_test.dart";
 import "package:path/path.dart" as path;
 
 void main() {
+  test("default FTP client refuses to overwrite a changed index", () async {
+    final tempDir = await Directory.systemTemp.createTemp("ftp_revision_");
+    try {
+      final index = File(path.join(tempDir.path, "app-archive.json"));
+      await index.writeAsString("new index");
+      final operations = RecordingFtpRemoteOperations()
+        ..files["/updates/app-archive.json"] = "old index".codeUnits;
+      final client = CurlFtpRemoteFileClient(operations: operations);
+
+      await expectLater(
+        client.writeIndexFileWithLease(
+          file: index,
+          remotePath: "/updates/app-archive.json",
+          config: const FtpUploadConfig(
+            host: "localhost",
+            remotePath: "/updates",
+            username: "deploy",
+            allowInsecure: true,
+          ),
+          expectedRevision: const RemoteIndexRevision.present(
+            sha256:
+                "0000000000000000000000000000000000000000000000000000000000000000",
+            etag: null,
+          ),
+        ),
+        throwsA(
+          isA<StateError>().having(
+            (error) => error.message,
+            "message",
+            contains("changed before publish"),
+          ),
+        ),
+      );
+
+      expect(
+        String.fromCharCodes(operations.files["/updates/app-archive.json"]!),
+        "old index",
+      );
+      expect(operations.directories, isEmpty);
+    } finally {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  test("default FTP client fails closed when the lease is occupied", () async {
+    final tempDir = await Directory.systemTemp.createTemp("ftp_lock_");
+    try {
+      final index = File(path.join(tempDir.path, "app-archive.json"));
+      await index.writeAsString("new index");
+      final operations = RecordingFtpRemoteOperations()
+        ..directories.add("/updates/.app-archive.json.desktop_updater.lock");
+      final client = CurlFtpRemoteFileClient(operations: operations);
+
+      await expectLater(
+        client.writeIndexFileWithLease(
+          file: index,
+          remotePath: "/updates/app-archive.json",
+          config: const FtpUploadConfig(
+            host: "localhost",
+            remotePath: "/updates",
+            username: "deploy",
+            allowInsecure: true,
+          ),
+          expectedRevision: const RemoteIndexRevision.absent(),
+        ),
+        throwsA(isA<StateError>()),
+      );
+
+      expect(operations.files, isEmpty);
+      expect(
+        operations.directories,
+        contains("/updates/.app-archive.json.desktop_updater.lock"),
+      );
+    } finally {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  test("default FTP client publishes a missing index with an exclusive lease",
+      () async {
+    final tempDir = await Directory.systemTemp.createTemp("ftp_lease_");
+    try {
+      final index = File(path.join(tempDir.path, "app-archive.json"));
+      await index.writeAsString("new index");
+      final operations = RecordingFtpRemoteOperations();
+      final client = CurlFtpRemoteFileClient(operations: operations);
+
+      final receipt = await client.writeIndexFileWithLease(
+        file: index,
+        remotePath: "/updates/app-archive.json",
+        config: const FtpUploadConfig(
+          host: "localhost",
+          remotePath: "/updates",
+          username: "deploy",
+          allowInsecure: true,
+        ),
+        expectedRevision: const RemoteIndexRevision.absent(),
+      );
+
+      expect(
+        String.fromCharCodes(operations.files["/updates/app-archive.json"]!),
+        "new index",
+      );
+      expect(operations.directories, isEmpty);
+      expect(operations.events, contains("rename"));
+      expect(receipt.observedPriorRevision, const RemoteIndexRevision.absent());
+      expect(receipt.mechanism, IndexPublishMechanism.exclusiveLease);
+      expect(receipt.leaseEvidenceSha256, matches(RegExp(r"^[0-9a-f]{64}$")));
+    } finally {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  test("default FTP client cleans a partial file after upload failure",
+      () async {
+    final tempDir =
+        await Directory.systemTemp.createTemp("ftp_upload_failure_");
+    try {
+      final index = File(path.join(tempDir.path, "app-archive.json"));
+      await index.writeAsString("new index");
+      final operations = RecordingFtpRemoteOperations()..failUpload = true;
+      final client = CurlFtpRemoteFileClient(operations: operations);
+
+      await expectLater(
+        client.writeIndexFileWithLease(
+          file: index,
+          remotePath: "/updates/app-archive.json",
+          config: const FtpUploadConfig(
+            host: "localhost",
+            remotePath: "/updates",
+            username: "deploy",
+            allowInsecure: true,
+          ),
+          expectedRevision: const RemoteIndexRevision.absent(),
+        ),
+        throwsA(isA<StateError>().having(
+          (error) => error.message,
+          "message",
+          contains("upload failed"),
+        )),
+      );
+
+      expect(operations.files, isEmpty);
+      expect(operations.directories, isEmpty);
+      expect(operations.events, contains("removeFile"));
+    } finally {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  test("default FTP client rejects a revision change after upload", () async {
+    final tempDir = await Directory.systemTemp.createTemp("ftp_revision_race_");
+    try {
+      final index = File(path.join(tempDir.path, "app-archive.json"));
+      await index.writeAsString("new index");
+      final oldBytes = "old index".codeUnits;
+      final operations = RecordingFtpRemoteOperations();
+      operations.files["/updates/app-archive.json"] = oldBytes;
+      operations.afterUpload = () {
+        operations.files["/updates/app-archive.json"] = "raced index".codeUnits;
+      };
+      final client = CurlFtpRemoteFileClient(operations: operations);
+
+      await expectLater(
+        client.writeIndexFileWithLease(
+          file: index,
+          remotePath: "/updates/app-archive.json",
+          config: const FtpUploadConfig(
+            host: "localhost",
+            remotePath: "/updates",
+            username: "deploy",
+            allowInsecure: true,
+          ),
+          expectedRevision: RemoteIndexRevision.present(
+            sha256: sha256.convert(oldBytes).toString(),
+            etag: null,
+          ),
+        ),
+        throwsA(isA<StateError>().having(
+          (error) => error.message,
+          "message",
+          contains("changed before publish"),
+        )),
+      );
+
+      expect(
+        String.fromCharCodes(operations.files["/updates/app-archive.json"]!),
+        "raced index",
+      );
+      expect(
+          operations.files.keys,
+          isNot(contains(
+            "/updates/.app-archive.json.desktop_updater.lock/app-archive.json.",
+          )));
+      expect(operations.directories, isEmpty);
+    } finally {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  test("default FTP client does not fall back when rename fails", () async {
+    final tempDir =
+        await Directory.systemTemp.createTemp("ftp_rename_failure_");
+    try {
+      final index = File(path.join(tempDir.path, "app-archive.json"));
+      await index.writeAsString("new index");
+      final operations = RecordingFtpRemoteOperations()..failRename = true;
+      final client = CurlFtpRemoteFileClient(operations: operations);
+
+      await expectLater(
+        client.writeIndexFileWithLease(
+          file: index,
+          remotePath: "/updates/app-archive.json",
+          config: const FtpUploadConfig(
+            host: "localhost",
+            remotePath: "/updates",
+            username: "deploy",
+            allowInsecure: true,
+          ),
+          expectedRevision: const RemoteIndexRevision.absent(),
+        ),
+        throwsA(isA<StateError>().having(
+          (error) => error.message,
+          "message",
+          contains("rename failed"),
+        )),
+      );
+
+      expect(operations.files, isEmpty);
+      expect(operations.directories, isEmpty);
+      expect(operations.events, contains("removeFile"));
+    } finally {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
   test("ftp config requires allowInsecure true", () async {
     await expectLater(
       ReleasePublishConfig.fromYaml("""
@@ -107,6 +344,79 @@ class RecordingFtpRemoteFileClient implements FtpRemoteFileClient {
     required FtpUploadConfig config,
   }) async {
     writes.add(FtpRemoteWrite(file: file, remotePath: remotePath));
+  }
+}
+
+class RecordingFtpRemoteOperations implements FtpRemoteOperations {
+  final files = <String, List<int>>{};
+  final directories = <String>{};
+  final events = <String>[];
+  bool failUpload = false;
+  bool failRename = false;
+  void Function()? afterUpload;
+
+  @override
+  Future<void> upload(
+    File file,
+    String remotePath,
+    FtpUploadConfig config,
+  ) async {
+    events.add("upload");
+    files[remotePath] = await file.readAsBytes();
+    afterUpload?.call();
+    if (failUpload) throw StateError("upload failed");
+  }
+
+  @override
+  Future<List<int>?> read(
+    String remotePath,
+    FtpUploadConfig config,
+  ) async {
+    events.add("read");
+    final value = files[remotePath];
+    return value == null ? null : List<int>.from(value);
+  }
+
+  @override
+  Future<void> makeDirectory(
+    String remotePath,
+    FtpUploadConfig config,
+  ) async {
+    events.add("makeDirectory");
+    if (!directories.add(remotePath)) {
+      throw StateError("directory already exists");
+    }
+  }
+
+  @override
+  Future<void> removeDirectory(
+    String remotePath,
+    FtpUploadConfig config,
+  ) async {
+    events.add("removeDirectory");
+    directories.remove(remotePath);
+  }
+
+  @override
+  Future<void> removeFile(
+    String remotePath,
+    FtpUploadConfig config,
+  ) async {
+    events.add("removeFile");
+    files.remove(remotePath);
+  }
+
+  @override
+  Future<void> rename(
+    String from,
+    String to,
+    FtpUploadConfig config,
+  ) async {
+    events.add("rename");
+    if (failRename) throw StateError("rename failed");
+    final value = files.remove(from);
+    if (value == null) throw StateError("source missing");
+    files[to] = value;
   }
 }
 


### PR DESCRIPTION
## What
The FTP provider publishes app-archive.json through an exclusive lease.

## Why
Two publishers can not update the index at the same time. The lease prevents this.

## How
- MKD creates the lease directory.
- The provider checks the hosted index revision before and after the upload.
- The provider renames the temporary file to the final name.
- If the FTP server refuses the rename onto an existing file, the provider falls back to a direct STOR overwrite.
- The provider verifies the published bytes after the upload.

## Tests
- FTP provider unit tests.
- Docker e2e helper updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved FTP release publishing with exclusive leasing and revision validation.
  - Added safer temporary uploads, atomic publication when supported, digest verification, and cleanup.
  - Added fallback handling when remote renaming is unavailable.

- **Bug Fixes**
  - Prevents conflicting or outdated index publications from overwriting newer releases.

- **Tests**
  - Expanded coverage for repeated FTP publishing, conflicts, cleanup, upload failures, and race conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->