### PR TITLE
fix(ftp): diagnose unsupported atomic replacement

### DIFF
--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -1532,6 +1532,31 @@ Set:
 DESKTOP_UPDATER_FTP_PASSWORD=...
 ```
 
+The FTP provider requires more than basic `RNFR`/`RNTO` support. After a
+complete temporary index is uploaded under the exclusive lease directory, the
+server must atomically replace the existing `app-archive.json` when `RNTO`
+names that existing destination. The source and destination must be on the
+same filesystem boundary, and a failed rename must leave publication safe to
+retry after the hosted index is validated.
+
+Apache FtpServer's native filesystem is not compatible with this requirement
+by default. Its
+[`NativeFtpFile.move`](https://github.com/apache/mina-ftpserver/blob/4ff3bc9a7898f9a15dc13416d8defbd9ed97dcf6/core/src/main/java/org/apache/ftpserver/filesystem/nativefs/impl/NativeFtpFile.java#L276-L290)
+implementation deliberately rejects a rename when the destination exists, and
+its
+[`testRenameToFileExists`](https://github.com/apache/mina-ftpserver/blob/4ff3bc9a7898f9a15dc13416d8defbd9ed97dcf6/core/src/test/java/org/apache/ftpserver/clienttests/RenameTest.java#L150-L161)
+test protects that behavior. If you control that server, install an allowlisted
+server-side atomic replacement that accepts only the lease temporary file and
+the exact live index path, verifies both paths remain inside the configured
+update root and on the same filesystem, and fails when the host cannot provide
+an atomic replace. Otherwise use SFTP, S3-compatible storage, or a
+`customCommand` backed by server-side atomic publication.
+
+Never work around this limitation with direct `STOR`, `DELE` followed by
+`RNTO`, or a multi-command backup shuffle. Direct upload can expose partial
+JSON, while delete and backup sequences create a window in which readers see
+no live index. The built-in FTP provider fails closed instead.
+
 Prefer SFTP or S3-compatible upload for production.
 
 ### Custom Command
@@ -1678,5 +1703,10 @@ workflow skeleton.
 - `AWS CLI executable not found`: install `aws` or use another provider.
 - `ftp.allowInsecure: true is required`: use SFTP/S3, or explicitly opt in for
   a legacy FTP host.
+- `FTP could not atomically replace ... with RNFR/RNTO`: verify rename
+  permissions and overwrite-rename support. Apache FtpServer's native
+  filesystem rejects an existing destination; configure a server-side atomic
+  replacement or use SFTP, S3-compatible storage, or a `customCommand` backed
+  by server-side atomic publication. Validate the hosted index before retrying.
 - Long `Cache-Control` on `app-archive.json`: keep index caching short so
   clients see newly published releases promptly.

--- a/lib/src/release_cli/doctor_command.dart
+++ b/lib/src/release_cli/doctor_command.dart
@@ -137,6 +137,15 @@ Future<void> _writeConfigDiagnostics(
     output
         .writeln("OK: upload provider = ${config.uploadProvider.providerName}");
   }
+  if (config.uploadProvider is FtpUploadConfig) {
+    output.writeln(
+      "WARNING: Confirm the FTP server allows RNTO to atomically replace an "
+      "existing destination. Apache FtpServer's native filesystem does not "
+      "support this by default; configure an allowlisted server-side atomic "
+      "replacement or use SFTP, S3-compatible storage, or a customCommand "
+      "backed by server-side atomic publication.",
+    );
+  }
 
   switch (platform) {
     case "windows":

--- a/lib/src/release_cli/upload/ftp_upload_provider.dart
+++ b/lib/src/release_cli/upload/ftp_upload_provider.dart
@@ -226,7 +226,22 @@ class CurlFtpRemoteFileClient implements ExclusiveLeaseFtpRemoteFileClient {
         expectedRevision: expectedRevision,
         actualBytes: await operations.read(remotePath, config),
       );
-      await operations.rename(temporaryPath, remotePath, config);
+      try {
+        await operations.rename(temporaryPath, remotePath, config);
+      } on Object catch (error) {
+        throw StateError(
+          "FTP could not atomically replace $remotePath with RNFR/RNTO. "
+          "Publication stopped and did not fall back to STOR on the live "
+          "index. Verify rename permissions and that the server allows RNTO "
+          "to replace an existing destination. Apache FtpServer's native "
+          "filesystem rejects that operation; configure an allowlisted "
+          "server-side atomic replacement or use SFTP, S3-compatible "
+          "storage, or a customCommand backed by server-side atomic "
+          "publication. Before retrying, validate the hosted index because a "
+          "lost server reply can leave its state uncertain. "
+          "Rename error: $error",
+        );
+      }
       temporaryFileExists = false;
 
       final publishedBytes = await operations.read(remotePath, config);

--- a/test/release_cli/release_doctor_test.dart
+++ b/test/release_cli/release_doctor_test.dart
@@ -108,6 +108,40 @@ updates:
     }
   });
 
+  test("FTP provider reports the atomic replacement requirement", () async {
+    final root = await _createProject(
+      config: """
+updates:
+  baseUrl: https://updates.example.com
+ftp:
+  host: ftp.example.com
+  remotePath: /updates
+  username: deploy
+  allowInsecure: true
+""",
+    );
+    try {
+      final output = StringBuffer();
+
+      final exitCode = await runReleaseCommand(
+        ["doctor", "--platform", "linux"],
+        projectRoot: root,
+        output: output,
+      );
+
+      expect(exitCode, 0);
+      expect(output.toString(), contains("OK: upload provider = ftp"));
+      expect(
+        output.toString(),
+        contains("RNTO to atomically replace an existing destination"),
+      );
+      expect(output.toString(), contains("Apache FtpServer"));
+      expect(output.toString(), contains("server-side atomic replacement"));
+    } finally {
+      await root.delete(recursive: true);
+    }
+  });
+
   test("windows without pre-package signing hook warns only", () async {
     final root = await _createProject(config: _minimalConfig);
     try {

--- a/test/release_cli/upload/ftp_upload_provider_test.dart
+++ b/test/release_cli/upload/ftp_upload_provider_test.dart
@@ -210,7 +210,7 @@ void main() {
     }
   });
 
-  test("default FTP client fails closed when rename fails", () async {
+  test("default FTP client explains unsupported atomic replacement", () async {
     final tempDir =
         await Directory.systemTemp.createTemp("ftp_rename_failure_");
     try {
@@ -238,11 +238,32 @@ void main() {
           ),
         ),
         throwsA(
-          isA<StateError>().having(
-            (error) => error.message,
-            "message",
-            contains("rename failed"),
-          ),
+          isA<StateError>()
+              .having(
+                (error) => error.message,
+                "message",
+                contains("RNFR/RNTO"),
+              )
+              .having(
+                (error) => error.message,
+                "message",
+                contains("Apache FtpServer"),
+              )
+              .having(
+                (error) => error.message,
+                "message",
+                contains("did not fall back to STOR"),
+              )
+              .having(
+                (error) => error.message,
+                "message",
+                contains("SFTP"),
+              )
+              .having(
+                (error) => error.message,
+                "message",
+                contains("rename failed"),
+              ),
         ),
       );
 
@@ -364,6 +385,16 @@ ftp:
         ),
       ),
     );
+  });
+
+  test("publishing guide documents FTP atomic replacement requirements", () {
+    final publishingGuide = File("docs/publishing.md").readAsStringSync();
+
+    expect(publishingGuide, contains("Apache FtpServer's native filesystem"));
+    expect(publishingGuide, contains("server-side atomic replacement"));
+    expect(publishingGuide, contains("Never work around this limitation"));
+    expect(publishingGuide, contains("direct `STOR`"));
+    expect(publishingGuide, contains("SFTP, S3-compatible storage"));
   });
 
   test("ftp uploader rejects app archive publish without lease", () async {


### PR DESCRIPTION
## Summary

- keep FTP index publication fail-closed when a server cannot replace an existing destination with `RNTO`
- turn the raw rename failure into an actionable diagnostic and surface the capability requirement in `release doctor`
- document Apache FtpServer's default behavior, the server-side atomic replacement requirement, and safe provider alternatives

## Root cause

Reported by @Nicoeevee in [PR #71's review thread](https://github.com/MarlonJD/flutter_desktop_updater/pull/71#discussion_r3772283998).

Apache FtpServer's native filesystem deliberately rejects rename when the destination already exists. RFC 959 does not provide a portable FTP-only atomic overwrite sequence, so `STOR`, `DELE` + `RNTO`, and backup shuffles would weaken the publication guarantee.

This change keeps the existing safe behavior and directs operators to an allowlisted server-side atomic replacement or SFTP, S3-compatible storage, or a `customCommand` backed by server-side atomic publication.

## Validation

- `flutter test --no-pub test/release_cli/upload/ftp_upload_provider_test.dart test/release_cli/release_doctor_test.dart`
- `flutter test --no-pub test/release_cli`
- `dart format --output=none --set-exit-if-changed .`
- `flutter analyze --no-fatal-infos`
- `flutter test --no-pub`
- `dart run tool/version_check.dart`
- `dart pub publish --dry-run`
